### PR TITLE
Only provision local databases if needed

### DIFF
--- a/playbooks/opencraft_integration.yml
+++ b/playbooks/opencraft_integration.yml
@@ -19,6 +19,9 @@
     COMMON_ENABLE_DATADOG: False
     COMMON_ENABLE_SPLUNKFORWARDER: False
     ENABLE_LEGACY_ORA: !!null
+  pre_tasks:
+    - name: install memcached
+      apt: pkg=memcached state=present
   roles:
     - role: nginx
       nginx_sites:

--- a/playbooks/opencraft_integration.yml
+++ b/playbooks/opencraft_integration.yml
@@ -26,6 +26,8 @@
       - lms
       nginx_default_sites:
       - lms
-    - edxlocal
-    - mongo
+    - role: edxlocal
+      when: EDXAPP_MYSQL_HOST == 'localhost'
+    - role: mongo
+      when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - edxapp


### PR DESCRIPTION
This pull request modifies the playbook used for opencraft integration tests to only provision mysql and mongo databases if needed. It's basically the same as https://github.com/edx/configuration/pull/2310.

@antoviaque @smarnach does this look ok?