### PR TITLE
edxlocal: Fix "String ... is too long for username" error.

### DIFF
--- a/playbooks/roles/edxlocal/tasks/main.yml
+++ b/playbooks/roles/edxlocal/tasks/main.yml
@@ -111,7 +111,7 @@
 
 - name: setup users for ecommerce
   mysql_user: >
-    name="{{ ECOMMERCE_DEFAULT_DB_NAME }}"
+    name="{{ ECOMMERCE_DATABASES.default.USER }}"
     password="{{ ECOMMERCE_DATABASES.default.PASSWORD }}"
     priv='{{ ECOMMERCE_DEFAULT_DB_NAME }}.*:SELECT,INSERT,UPDATE,DELETE'
   when: ECOMMERCE_DEFAULT_DB_NAME is defined


### PR DESCRIPTION
Stop reusing `ECOMMERCE_DEFAULT_DB_NAME` for corresponding user.
Use `ECOMMERCE_DATABASES.default.USER` instead.

This error surfaced in the context of https://github.com/open-craft/opencraft/pull/84: mysql.yml didn't contain ecommerce credentials before, so the `edxlocal` role never ran any ecommerce-related tasks. As a result, it didn't matter that the number of characters in `ECOMMERCE_DEFAULT_DB_NAME` exceeded the maximum number of characters allowed for MySQL usernames.