### PR TITLE
Add Let's Encrypt to integration playbook

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -36,7 +36,6 @@
     - edxapp
     - notifier
     - analytics_api
-    - insights
     - edx_notes_api
     - demo
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }

--- a/playbooks/opencraft_integration.yml
+++ b/playbooks/opencraft_integration.yml
@@ -1,0 +1,31 @@
+---
+
+# Example sandbox configuration
+# for single server community
+# installs
+
+- name: Configure instance(s)
+  hosts: all
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+    openid_workaround: True
+    EDXAPP_LMS_NGINX_PORT: '80'
+    edx_platform_version: 'master'
+    # Set to false if deployed behind another proxy/load balancer.
+    NGINX_SET_X_FORWARDED_HEADERS: True
+    # These should stay false for the public AMI
+    COMMON_ENABLE_DATADOG: False
+    COMMON_ENABLE_SPLUNKFORWARDER: False
+    ENABLE_LEGACY_ORA: !!null
+  roles:
+    - role: nginx
+      nginx_sites:
+      - cms
+      - lms
+      nginx_default_sites:
+      - lms
+    - edxlocal
+    - mongo
+    - edxapp

--- a/playbooks/opencraft_integration.yml
+++ b/playbooks/opencraft_integration.yml
@@ -12,6 +12,11 @@
     migrate_db: "yes"
     openid_workaround: True
     EDXAPP_LMS_NGINX_PORT: '80'
+    EDXAPP_LMS_SSL_NGINX_PORT: '443'
+    NGINX_ENABLE_SSL: True
+    LETS_ENCRYPT_DOMAINS:
+      - "{{ EDXAPP_LMS_SITE_NAME }}"
+      - "{{ EDXAPP_CMS_SITE_NAME }}"
     edx_platform_version: 'master'
     # Set to false if deployed behind another proxy/load balancer.
     NGINX_SET_X_FORWARDED_HEADERS: True
@@ -29,3 +34,4 @@
     - edxlocal
     - mongo
     - edxapp
+    - lets_encrypt

--- a/playbooks/roles/edxlocal/tasks/main.yml
+++ b/playbooks/roles/edxlocal/tasks/main.yml
@@ -111,7 +111,7 @@
 
 - name: setup users for ecommerce
   mysql_user: >
-    name="{{ ECOMMERCE_DEFAULT_DB_NAME }}"
+    name="{{ ECOMMERCE_DATABASES.default.USER }}"
     password="{{ ECOMMERCE_DATABASES.default.PASSWORD }}"
     priv='{{ ECOMMERCE_DEFAULT_DB_NAME }}.*:SELECT,INSERT,UPDATE,DELETE'
   when: ECOMMERCE_DEFAULT_DB_NAME is defined

--- a/util/vagrant/migrate.sh
+++ b/util/vagrant/migrate.sh
@@ -2,7 +2,7 @@
 
 # defaults
 CONFIGURATION="fullstack"
-TARGET="named-release/cypress.rc"
+TARGET="named-release/cypress"
 INTERACTIVE=true
 OPENEDX_ROOT="/edx"
 


### PR DESCRIPTION
Let's Encrypt role and config settings added to integration
playbook, to automatically bring up integration test servers
with https.
