### PR TITLE
Redirect /tos and /honor to Cloudera.com's Terms of Service page.

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -225,4 +225,9 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
 
+
+  # Redirect the Terms of Service/Honor page to Cloudera's site
+  location ~ /(tos)|(honor)/?$ {
+        rewrite ^ https://www.cloudera.com/legal/terms-and-conditions.html permanent;
+  }
 }


### PR DESCRIPTION
Appends a redirect to the `lms.j2` nginx template.

**Sandbox URL**: (fresh appserver is being provisioned)

* LMS: http://pr52-cloudera.sandbox.opencraft.hosting/
* Studio: http://studio-pr52-cloudera.sandbox.opencraft.hosting/

**Testing instructions**:

1. If you've visited http://pr52-cloudera.sandbox.opencraft.hosting/ before, clear your browser history to avoid any cached permanent redirects.  (I can't seem to get Chrome to respect this, but Firefox does.)
1. Visit http://pr52-cloudera.sandbox.opencraft.hosting/register
1. Verify that the [Terms of Service and Honor Code](https://pr52-cloudera.sandbox.opencraft.hosting/honor) link redirects to cloudera.com's Terms And Conditions page.
1. Visit https://pr52-cloudera.sandbox.opencraft.hosting/
1. Verify that the [Terms of Service](https://pr52-cloudera.sandbox.opencraft.hosting/tos) and [Honor Code](https://pr52-cloudera.sandbox.opencraft.hosting/honor) links redirect to cloudera.com's Terms And Conditions page.

**Author notes and concerns**:

1. I really wanted to use the branding app's [Alternate marketing site links](https://github.com/edx/edx-platform/wiki/Alternate-site-for-marketing-links#to-run-with-an-alternate-marketing-site] feature for this, but alas, it doesn't work unless you're willing to also replace `/` and `/courses` with an alternate site.

**Reviewers**
- [ ] @bradenmacdonald 

CC @bdero   