### PR TITLE
Always autorestart edxapp workers.

### DIFF
--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -10,6 +10,7 @@ stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 command={{ edxapp_venv_dir + '/bin/newrelic-admin run-program ' if w.monitor and COMMON_ENABLE_NEWRELIC_APP else ''}}{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings={{ worker_django_settings_module }} celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }}
 killasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(EDXAPP_WORKER_DEFAULT_STOPWAITSECS) }}
+autorestart=true
 
 {% endfor %}
 


### PR DESCRIPTION
By default supervisor will only automatically restart services when they exit code is not `0` or `2`.
Edxapp workers sometimes exit with a code of `0` on certain network failures, so make sure they are restarted even if exit code is `0`.

**Reviewers**:

- [ ] @bdero 