### PR TITLE
Run the AWS role before the edxapp role

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -49,11 +49,11 @@
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - role: rabbitmq
       rabbitmq_ip: 127.0.0.1
+    - role: aws
+      when: COMMON_ENABLE_AWS_INTEGRATION
     - role: edxapp
       celery_worker: True
     - edxapp
-    - role: aws
-      when: COMMON_ENABLE_AWS_INTEGRATION
     - role: openstack
       when: COMMON_ENABLE_OPENSTACK_INTEGRATION
     - role: ecommerce


### PR DESCRIPTION
This solves a problem where `s3cmd` doesn't get installed into `/usr/local/bin` when running the AWS role, since the `edxapp` role installs the distro package for `s3cmd` and the `pip` package (installed by the `aws` role) will only install `s3cmd` to `/usr/local/bin` if `s3cmd` isn't already somewhere in the `PATH`.

CC @bradenmacdonald @mtyaka 