### PR TITLE
Add discovery to sandbox playbook

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -24,7 +24,9 @@
     # These should stay false for the public AMI
     COMMON_ENABLE_DATADOG: False
     SANDBOX_ENABLE_ECOMMERCE: False
+    SANDBOX_ENABLE_DISCOVERY: False
     COMMON_ENABLE_SPLUNKFORWARDER: False
+    ENABLE_DISCOVERY_METADATA_REFRESH_CRONTASK: True
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 2GB
@@ -41,6 +43,10 @@
       nginx_sites:
       - ecommerce
       when: SANDBOX_ENABLE_ECOMMERCE
+    - role: nginx
+      nginx_sites:
+      - discovery
+      when: SANDBOX_ENABLE_DISCOVERY
     - role: edxlocal
       when: EDXAPP_MYSQL_HOST == 'localhost'
     - role: memcache
@@ -61,6 +67,8 @@
     - role: ecomworker
       ECOMMERCE_WORKER_BROKER_HOST: 127.0.0.1
       when: SANDBOX_ENABLE_ECOMMERCE
+    - role: discovery
+      when: SANDBOX_ENABLE_DISCOVERY
     - programs
     # not ready yet: - edx_notes_api
     - demo

--- a/playbooks/roles/discovery/tasks/main.yml
+++ b/playbooks/roles/discovery/tasks/main.yml
@@ -236,3 +236,11 @@
   tags:
     - install
     - install:vhosts
+
+- name: Add daily course metadata refresh crontask
+  cron:
+    special_time: daily
+    state: present
+    name: "course-metadata-refresh"
+    job: ". {{ COMMON_APP_DIR }}/discovery/discovery_env; {{ COMMON_BIN_DIR }}/manage.discovery refresh_course_metadata"
+  when: ENABLE_DISCOVERY_METADATA_REFRESH_CRONTASK

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/discovery.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/discovery.j2
@@ -1,0 +1,86 @@
+#
+# {{ ansible_managed }}
+#
+
+
+{% if nginx_default_sites is defined and "discovery" in nginx_default_sites %}
+  {% set default_site = "default" %}
+{% else %}
+  {% set default_site = "" %}
+{% endif %}
+
+upstream discovery_app_server {
+{% for host in nginx_discovery_gunicorn_hosts %}
+    server {{ host }}:{{ discovery_gunicorn_port }} fail_timeout=0;
+{% endfor %}
+}
+
+server {
+  server_name {{ DISCOVERY_HOSTNAME }};
+
+  {% if NGINX_ENABLE_SSL %}
+
+  listen {{ DISCOVERY_NGINX_PORT }} {{ default_site }};
+  listen {{ DISCOVERY_SSL_NGINX_PORT }} ssl;
+
+  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
+  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
+  # request the browser to use SSL for all connections
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+
+  {% else %}
+  listen {{ DISCOVERY_NGINX_PORT }} {{ default_site }};
+  {% endif %}
+
+  location ~ ^/static/(?P<file>.*) {
+    root {{ COMMON_DATA_DIR }}/{{ discovery_service_name }};
+    try_files /staticfiles/$file =404;
+  }
+
+  location / {
+    try_files $uri @proxy_to_app;
+  }
+
+  {% include "robots.j2" %}
+
+  location @proxy_to_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
+    proxy_set_header Host $http_host;
+
+    proxy_redirect off;
+    proxy_pass http://discovery_app_server;
+  }
+  # Nginx does not support nested condition or or conditions so
+  # there is an unfortunate mix of conditonals here.
+  {% if NGINX_REDIRECT_TO_HTTPS %}
+     {% if NGINX_HTTPS_REDIRECT_STRATEGY == "scheme" %}
+  # Redirect http to https over single instance
+  if ($scheme != "https")
+  {
+   set $do_redirect_to_https "true";
+  }
+
+    {% elif NGINX_HTTPS_REDIRECT_STRATEGY == "forward_for_proto" %}
+
+  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB
+  if ($http_x_forwarded_proto = "http")
+  {
+   set $do_redirect_to_https "true";
+  }
+     {% endif %}
+
+  # Execute the actual redirect
+  if ($do_redirect_to_https = "true")
+  {
+  rewrite ^ https://$host$request_uri? permanent;
+  }
+  {% endif %}
+}


### PR DESCRIPTION
This pull request updates the edx_sandbox playbook to allow the installation of a Course Discovery stack alongside the other system components.

---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
