### PR TITLE
Add optional fallback DNS servers to resolvconf

### DIFF
--- a/playbooks/roles/common/handlers/main.yml
+++ b/playbooks/roles/common/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart networking
+  service:
+    name: networking
+    state: restarted

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -145,6 +145,15 @@
   shell: hostname -F /etc/hostname
   when: COMMON_HOSTNAME|length >0 and (etc_hosts.changed or etc_hostname.changed)
 
+- name: Add fallback DNS servers to resolvconf
+  lineinfile:
+    dest: /etc/resolvconf/resolv.conf.d/tail
+    line: "nameserver {{ item }}"
+    create: yes
+    state: present
+  with_items: "{{ COMMON_FALLBACK_DNS_SERVERS }}"
+  notify: restart networking
+
 - name: Copy the templates to their respestive destination
   template:
     dest: "{{ item.dest }}"

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -80,6 +80,9 @@ COMMON_GIT_PATH: 'edx'  # git path prefix
 # override this var to set a different hostname
 COMMON_HOSTNAME: ""
 
+# List of DNS server addresses to append to resolvconf
+COMMON_FALLBACK_DNS_SERVERS: []
+
 # Set to true to customize DNS search domains
 COMMON_CUSTOM_DHCLIENT_CONFIG: false
 # uncomment and specifity your domains.
@@ -122,6 +125,7 @@ common_redhat_pkgs:
   - git
   - unzip
   - acl
+  - resolvconf
 common_debian_pkgs:
   - ntp
   - acl
@@ -132,6 +136,7 @@ common_debian_pkgs:
   - unzip
   - python-pip
   - python2.7-dev
+  - resolvconf
 
 # Packages that should be installed from our custom PPA, i.e. COMMON_EDX_PPA
 old_python_debian_pkgs:


### PR DESCRIPTION
This change adds optional DNS fallback servers via resolvconf. It accomplishes the same goal as https://github.com/open-craft/ansible-common-server/pull/6, except that it's more generally applicable.

CC @smarnach 