### PR TITLE
Fix Oracle JDK download errors

### DIFF
--- a/playbooks/roles/oraclejdk/defaults/main.yml
+++ b/playbooks/roles/oraclejdk/defaults/main.yml
@@ -1,13 +1,15 @@
 ---
 
-oraclejdk_version: "8u65"
+oraclejdk_version: "8u131"
 # what the archive unpacks to
-oraclejdk_base: "jdk1.8.0_65"
-oraclejdk_build: "b17"
+oraclejdk_base: "jdk1.8.0_131"
+oraclejdk_build: "b11"
 oraclejdk_platform: "linux"
 oraclejdk_arch: "x64"
 oraclejdk_file: "jdk-{{ oraclejdk_version }}-{{ oraclejdk_platform }}-{{ oraclejdk_arch }}.tar.gz"
-oraclejdk_url: "http://download.oracle.com/otn-pub/java/jdk/{{ oraclejdk_version }}-{{ oraclejdk_build }}/{{ oraclejdk_file }}"
+
+oraclejdk_url: "http://download.oracle.com/otn-pub/java/jdk/{{ oraclejdk_version }}-{{ oraclejdk_build }}/d54c1d3a095b4ff2b6607d096fa80163/{{ oraclejdk_file }}"
+
 oraclejdk_link: "/usr/lib/jvm/java-8-oracle"
 
 oraclejdk_debian_pkgs:


### PR DESCRIPTION
By cherry-picking the commit that fixes this on edx/configuration master.

The old version of the JDK is no longer available, so we need to use a newer one.