### PR TITLE
Whitelist the Appsembler APIs from basic auth

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -208,6 +208,11 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  # No basic auth an appsembler bulk enroll API etc.
+  location /appsembler {
+    try_files $uri @proxy_to_lms_app;
+  }
+
   # No basic auth security on the github_service_hook url, so that github can use it for cms
   location /github_service_hook {
     try_files $uri @proxy_to_lms_app;


### PR DESCRIPTION
Boomi was unable to use the appsembler bulk enroll API because its endpoint was not one of the API endpoints whitelisted for exclusion from HTTP basic authentication.

I have already deployed this fix on the live instances and confirmed that it fixes the issue.

This is a temporary fix that will be redundant once OC-2452 is completed, since the upstream version is in the `/api` URL space.