### PR TITLE
Don't consume basic auth for the upstreamed bulk-enroll API

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -213,6 +213,10 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  location /api/bulk_enroll {
+    try_files $uri @proxy_to_lms_app;
+  }
+
   # No basic auth security on the github_service_hook url, so that github can use it for cms
   location /github_service_hook {
     try_files $uri @proxy_to_lms_app;


### PR DESCRIPTION
Part of: https://tasks.opencraft.com/browse/OC-2453

Don't consume basic auth for `/api/bulk_enroll`, as the authorization bring passed through from the client is required to use this API.