### PR TITLE
To deal with memory issues, default to less edxapp workers.

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -18,6 +18,10 @@
   vars:
     migrate_db: "yes"
     EDXAPP_LMS_NGINX_PORT: '80'
+    # Deal with noted memory issues
+    EDXAPP_WORKERS:
+      lms: 3
+      cms: 2
     edx_platform_version: 'master'
     # Set to false if deployed behind another proxy/load balancer.
     NGINX_SET_X_FORWARDED_HEADERS: True


### PR DESCRIPTION
We've noted some memory issues that can be solved by reducing the number of LMS/CMS workers.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

(TBD)
1. See stage for a new instance that uses this configuration branch.
1. See its configuration setup and make sure you see

```yaml
EDXAPP_WORKERS:
  lms: 3
  cms: 2
```