### PR TITLE
Intercept proxy errors from edxapp.

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -67,6 +67,10 @@ server {
 error_page {{ k }} {{ v }};
   {% endfor %}
 
+  {% if NGINX_PROXY_INTERCEPT_ERRORS %}
+  proxy_intercept_errors on;
+  {% endif %}
+
   listen {{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};
 
   {% if NGINX_ENABLE_SSL %}


### PR DESCRIPTION
This is required for nginx to use custom error pages when the errors originate from the proxy backend (which they do most of the time).

This change was also added to https://github.com/edx/configuration/pull/4558.

**Testing instructions**:

This branch was used to deploy the new oc-edxapp-stage-2-1 appserver. You can check that the custom error page works correctly by going a non-existent page, for example: https://stage.onlinelearning.hms.harvard.edu/courses/course-v1%3AHMX%2BBCM%2B2017_09_PCR/ooopsidontexist/
