### PR TITLE
[BB-187] Add optional aws role integration to edx_sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: common_vars
+  - Added `COMMON_ENABLE_AWS_INTEGRATION` to run the `aws` role when enabled. Default: `False`.
+
 - Use Ansible 2.3.1.0 so that we can do shallow clones of tags.
 
 - git_clone:

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -33,6 +33,8 @@
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB
+    - role: aws
+      when: COMMON_ENABLE_AWS_INTEGRATION
     - role: nginx
       nginx_sites:
       - certs

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -14,6 +14,9 @@ COMMON_BASIC_AUTH_EXCEPTIONS:
 # Settings to use for calls to edxapp manage.py
 COMMON_EDXAPP_SETTINGS: 'aws'
 
+# Set to True to install aws role when running edx_sandbox playbook.
+COMMON_ENABLE_AWS_INTEGRATION: False
+
 # Turn on syncing logs on rotation for edx
 # application and tracking logs, must also
 # have the aws or openstack role installed


### PR DESCRIPTION
This allows enabling `aws` role for sandboxes by using additional variable `COMMON_ENABLE_AWS_INTEGRATION` (which is [already set](https://github.com/open-craft/opencraft/blob/5c3f56732c7ba26d06d1267f290edeb8d4897bcf/instance/models/mixins/openedx_storage.py#L62) in Ocim).

With this role added, the logs from Ocim instances can be uploaded to S3.

**Sandbox IP:**  54.36.52.103

**Testing instructions:**
- Create an instance with `config_version = 'agrendalath/hawthorn.1-s3-logrotate'` (or use an existing one).
- Add something to logs: e.g. `echo TEST | sudo tee --append /edx/var/log/tracking/tracking.log`.
- Upload the logs: `sudo logrotate -f /etc/logrotate.d/hourly/tracking.log`. You will get something like 's3://.*.gz' in the stdout - this will be the $FILE_URL needed for the next step).
- Get the file: `s3cmd --access_key $AWS_S3_LOGS_ACCESS_KEY_ID --secret_key $AWS_S3_LOGS_SECRET_KEY get $FILE_URL` (you can get the keys from appserver 'Configuration' in Ocim or from the `/edx/bin/send-logs-to-object-store` file).
- Ensure that the downloaded file contains the sent phrase: e.g. with: `zgrep TEST $DOWNLOADED_FILE`.