### PR TITLE
Allow to explicitly disable memcached for sandbox installs.

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -29,6 +29,7 @@
     SANDBOX_ENABLE_ANALYTICS_API: true
     SANDBOX_ENABLE_INSIGHTS: true
     SANDBOX_ENABLE_RABBITMQ: true
+    SANDBOX_ENABLE_MEMCACHE: "'localhost' in ' '.join(EDXAPP_MEMCACHE)"
     JOURNALS_ENABLED: false
   roles:
     - role: swapfile
@@ -45,7 +46,7 @@
     - role: edxlocal
       when: EDXAPP_MYSQL_HOST == 'localhost'
     - role: memcache
-      when: "'localhost' in ' '.join(EDXAPP_MEMCACHE)"
+      when: SANDBOX_ENABLE_MEMCACHE
     - role: mongo_3_2
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - role: rabbitmq


### PR DESCRIPTION
Since we are running the Consul Connect proxies locally, the `EDXAPP_MEMCACHE` setting will point to `localhost`, but we don't want to install memcached anyway.  This change makes it possible to explicitly configure whether memcache should be installed, in a backwards-compatible way.