### PR TITLE
Adds daily cron jobs for schedules app emails

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -798,6 +798,15 @@ EDXAPP_CLEARSESSIONS_CRON_ENABLED: false
 EDXAPP_CLEARSESSIONS_CRON_HOURS: "14"
 EDXAPP_CLEARSESSIONS_CRON_MINUTES: "0"
 
+# Optionally add daily cron jobs to run the management command that send the configured Schedules emails
+# cf https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/schedules/docs/README.rst#running-the-management-commands
+# e.g.,
+# EDXAPP_SCHEDULES_EMAIL_CRONS_ENABLED:
+#  - { command: 'send_recurring_nudge', hour: 0, minute: 0 }
+#  - { command: 'send_upgrade_reminder', hour: 1, minute: 0 }
+#  - { command: 'send_course_update', hour: 2, minute: 0 }
+EDXAPP_SCHEDULES_EMAIL_CRONS_ENABLED: []
+
 EDXAPP_VIDEO_IMAGE_MAX_AGE: 31536000
 
 # This is django storage configuration for Video Image settings.

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -475,3 +475,13 @@
     minute: "{{ EDXAPP_CLEARSESSIONS_CRON_MINUTES }}"
     day: "*"
   when: EDXAPP_CLEARSESSIONS_CRON_ENABLED
+
+- name: install daily cron jobs to send scheduled emails
+  cron:
+    name: "Scheduled {{ item.command }}"
+    user: "{{ edxapp_user }}"
+    job: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms {{ item.command }} --settings={{ edxapp_settings }} >/dev/null 2>&1"
+    hour: "{{ item.hour | default(0) }}"
+    minute: "{{ item.minute | default(0) }}"
+    day: "*"
+  with_items: "{{ EDXAPP_SCHEDULES_EMAIL_CRONS_ENABLED }}"


### PR DESCRIPTION
Adds configuration variables to schedule the cron jobs required to send emails from the [Schedules app](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/schedules/docs/README.rst#running-the-management-commands).

**JIRA tickets**: SE-126

**Sandbox URL**: Will test on production instance.

**Testing instructions**:

1. Ensure that entry has been created in {{edxapp}} user's cron

**Author notes and concerns**:

1. Will need to submit upstream PR.

**Reviewers**
- [ ] TBD

**Settings**
```yaml
EDXAPP_SCHEDULES_EMAIL_CRONS_ENABLED
- { command: 'send_course_update', hour: 2, minute: 0 }
```