### PR TITLE
(BB-729) Variable to add extra custom config blocks to lms and cms nginx templates

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -182,3 +182,6 @@ NGINX_EDXAPP_CMS_APP_EXTRA: ""
 NGINX_EDXAPP_LMS_APP_EXTRA: ""
 
 NGINX_DJANGO_ADMIN_ACCESS_CIDRS: []
+# Variable to add extra custom rules to CMS and LMS nginx server block.
+NGINX_EDXAPP_CMS_EXTRA: ""
+NGINX_EDXAPP_LMS_EXTRA: ""

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -100,6 +100,10 @@ error_page {{ k }} {{ v }};
     {{ NGINX_EDXAPP_CMS_APP_EXTRA }}
   }
 
+  {% if NGINX_EDXAPP_CMS_EXTRA|length %}
+      {{ NGINX_EDXAPP_CMS_EXTRA }}
+  {% endif %}
+
   location / {
     {% if EDXAPP_CMS_ENABLE_BASIC_AUTH|bool %}
       {% include "basic-auth.j2" %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -100,7 +100,7 @@ error_page {{ k }} {{ v }};
     {{ NGINX_EDXAPP_CMS_APP_EXTRA }}
   }
 
-  {% if NGINX_EDXAPP_CMS_EXTRA|length %}
+  {% if NGINX_EDXAPP_CMS_EXTRA is defined and NGINX_EDXAPP_CMS_EXTRA is sameas true %}
       {{ NGINX_EDXAPP_CMS_EXTRA }}
   {% endif %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -100,7 +100,7 @@ error_page {{ k }} {{ v }};
     {{ NGINX_EDXAPP_CMS_APP_EXTRA }}
   }
 
-  {% if NGINX_EDXAPP_CMS_EXTRA is defined and NGINX_EDXAPP_CMS_EXTRA is sameas true %}
+  {% if NGINX_EDXAPP_CMS_EXTRA is defined and NGINX_EDXAPP_CMS_EXTRA %}
       {{ NGINX_EDXAPP_CMS_EXTRA }}
   {% endif %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -153,6 +153,10 @@ error_page {{ k }} {{ v }};
     {{ NGINX_EDXAPP_LMS_APP_EXTRA }}
   }
 
+  {% if NGINX_EDXAPP_LMS_EXTRA|length %}
+      {{ NGINX_EDXAPP_LMS_EXTRA }}
+  {% endif %}
+
   location / {
     {% if EDXAPP_LMS_ENABLE_BASIC_AUTH|bool %}
       {% include "basic-auth.j2" %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -153,7 +153,7 @@ error_page {{ k }} {{ v }};
     {{ NGINX_EDXAPP_LMS_APP_EXTRA }}
   }
 
-  {% if NGINX_EDXAPP_LMS_EXTRA|length %}
+  {% if NGINX_EDXAPP_LMS_EXTRA is defined and NGINX_EDXAPP_LMS_EXTRA is sameas true %}
       {{ NGINX_EDXAPP_LMS_EXTRA }}
   {% endif %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -153,7 +153,7 @@ error_page {{ k }} {{ v }};
     {{ NGINX_EDXAPP_LMS_APP_EXTRA }}
   }
 
-  {% if NGINX_EDXAPP_LMS_EXTRA is defined and NGINX_EDXAPP_LMS_EXTRA is sameas true %}
+  {% if NGINX_EDXAPP_LMS_EXTRA is defined and NGINX_EDXAPP_LMS_EXTRA %}
       {{ NGINX_EDXAPP_LMS_EXTRA }}
   {% endif %}
 


### PR DESCRIPTION
  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

**Rationale:**
This PR introduces two new optional variables `NGINX_EDXAPP_LMS_EXTRA` and `NGINX_EDXAPP_CMS_EXTRA`. The idea is to use these variables in case there's any extra custom configuration needed for nginx.
Our main use for this are clients who have other services running to manage their main site (e.g. wordpress) and they want specific redirects for the top domain. For instance, the site **learning.myschool.edu** wants every user to land on their wordpress site (**learning.myschool.edu/school**) instead of the default lms landing view. This can be managed through [edx-django-sites-extensions](https://github.com/edx/edx-django-sites-extensions) redirect app. The issue with this redirect app is that it will apply the redirect for the entire domain and since studio and lms share the same database then the previously described redirect applies for both lms' root and studio root. We end up with a redirect when a user goes to either **learning.myschool.edu** or **studio.learning.myschool.edu** to the wordpress site.
By adding this new variables we can add an nginx rule such as 
```
location = / {
    redirect 301 https://$hostname/school;
}
```
That will only apply for lms (or cms if needed) and will not conflict with other subsites (e.g. studio).
The variables are optional in the case that they are not defined the jinja template will not print anything. This way we do not break previously provisioned instances.