### PR TITLE
Pin rubygems 

### DIFF
--- a/playbooks/roles/rbenv/defaults/main.yml
+++ b/playbooks/roles/rbenv/defaults/main.yml
@@ -6,6 +6,7 @@ rbenv_rake_version: '10.4.2'
 rbenv_root: "{{ rbenv_dir }}/.rbenv"
 rbenv_gem_root: "{{ rbenv_dir }}/.gem"
 rbenv_gem_bin: "{{ rbenv_gem_root }}/bin"
+rbenv_rubygems_version: '2.7.8'
 rbenv_bin: "{{ rbenv_dir }}/.rbenv/bin"
 rbenv_shims: "{{ rbenv_root }}/shims"
 rbenv_path: "{{ rbenv_bin }}:{{ rbenv_shims }}:{{ rbenv_gem_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -163,6 +163,14 @@
     - install
     - install:base
 
+- name: update rubygems
+  shell: "gem update --system {{ rbenv_rubygems_version }}"
+  become_user: "{{ rbenv_user }}"
+  environment: "{{ rbenv_environment }}"
+  tags:
+    - install
+    - install:base
+
 - name: install bundler
   shell: "gem install bundler -v {{ rbenv_bundler_version }}"
   become_user: "{{ rbenv_user }}"
@@ -187,14 +195,6 @@
     - install
     - install:base
 
-- name: update rubygems
-  shell: "gem install rubygems-update && update_rubygems"
-  become_user: "{{ rbenv_user }}"
-  environment: "{{ rbenv_environment }}"
-  tags:
-    - install
-    - install:base
-    
 - name: rehash
   shell: "rbenv rehash"
   become_user: "{{ rbenv_user }}"


### PR DESCRIPTION
Rubygems 3.0.0 was released recently and it is causing the following error when provisioning the forum service:

```
/edx/app/forum/.rbenv/versions/2.4.1/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file – rubygems/core_ext/kernel_warn (LoadError)
from /edx/app/forum/.rbenv/versions/2.4.1/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
from /edx/app/forum/.rbenv/versions/2.4.1/lib/ruby/site_ruby/2.4.0/rubygems.rb:1395:in `<top (required)>'
from <internal:gem_prelude>:4:in `require'
from <internal:gem_prelude>:4:in `<internal:gem_prelude>'}}
```

So we pin it to 2.7.8.