### PR TITLE
[BB-724] Add support for confuguing notes API app

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -30,6 +30,7 @@
     SANDBOX_ENABLE_INSIGHTS: true
     SANDBOX_ENABLE_RABBITMQ: true
     JOURNALS_ENABLED: false
+    EDX_NOTES_API_ENABLED: false
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB
@@ -65,7 +66,12 @@
       when: SANDBOX_ENABLE_ANALYTICS_API
     - role: insights
       when: SANDBOX_ENABLE_INSIGHTS
-    # not ready yet: - edx_notes_api
+    - role: edx_notes_api
+      when: EDX_NOTES_API_ENABLED
+    - role: nginx
+      nginx_sites:
+      - edx_notes_api
+      when: EDX_NOTES_API_ENABLED
     - demo
     - oauth_client_setup
     - oraclejdk

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -115,6 +115,7 @@ NGINX_EDXAPP_ERROR_PAGES:
   "504": "{{ nginx_default_error_page }}"
 
 CMS_HOSTNAME: '~^((stage|prod)-)?studio.*'
+EDX_NOTES_API_HOSTNAME: '~^((stage|prod)-)?notes.*'
 
 nginx_template_dir: "edx/app/nginx/sites-available"
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
@@ -1,3 +1,9 @@
+{%- if "edx_notes_api" in nginx_default_sites -%}
+  {%- set default_site = "default_server" -%}
+{%- else -%}
+  {%- set default_site = "" -%}
+{%- endif -%}
+
 upstream {{ edx_notes_api_service_name }}_app_server {
     {% for host in nginx_edx_notes_api_gunicorn_hosts %}
         server {{ host }}:{{ edx_notes_api_gunicorn_port }} fail_timeout=0;
@@ -5,7 +11,7 @@ upstream {{ edx_notes_api_service_name }}_app_server {
 }
 
 server {
-  listen {{ edx_notes_api_nginx_port }} default_server;
+  listen {{ edx_notes_api_nginx_port }} {{ default_site }};
 
   {% if NGINX_ENABLE_SSL %}
 
@@ -26,7 +32,9 @@ server {
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}
-  
+
+  server_name {{ EDX_NOTES_API_HOSTNAME }};
+
   location / {
     try_files $uri @proxy_to_app;
   }
@@ -47,4 +55,3 @@ location @proxy_to_app {
     proxy_pass http://{{ edx_notes_api_service_name }}_app_server;
   }
 }
-


### PR DESCRIPTION
Configuration Pull Request
---
Add support for enabling/disabling edx-notes-api via configuration variable.
Fix edx-notes-api configuration to include a hostname and to support toggling the default_site parameter. 

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
