### PR TITLE
[BB-757] Fix failover issue in forum service

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -11,6 +11,7 @@ forum_supervisor_wrapper: "{{ forum_app_dir }}/forum-supervisor.sh"
 forum_gem_root: "{{ forum_rbenv_dir }}/.gem"
 forum_gem_bin: "{{ forum_gem_root }}/bin"
 forum_path: "{{ forum_binstubs_dir }}:{{ forum_rbenv_bin }}:{{ forum_rbenv_shims }}:{{ forum_gem_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+forum_watchdog: "{{ forum_app_dir }}/forum-watchdog.sh"
 
 FORUM_MONGO_USER: "cs_comments_service"
 FORUM_MONGO_PASSWORD: "password"

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -35,6 +35,7 @@
     group: "{{ supervisor_user }}"
     mode: 0644
   become_user: "{{ supervisor_user }}"
+  when: not devstack
   tags:
     - install
     - install:configuration
@@ -48,7 +49,7 @@
     force: yes
     mode: 0644
   become_user: "{{ supervisor_user }}"
-  when: not disable_edx_services
+  when: not disable_edx_services and not devstack
   tags:
     - install
     - install:configuration
@@ -59,6 +60,7 @@
     dest: "{{ forum_watchdog }}"
     mode: 0755
   become_user: "{{ forum_user }}"
+  when: not devstack
   notify: restart the forum service when failover fails
   tags:
     - install

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -61,7 +61,6 @@
     mode: 0755
   become_user: "{{ forum_user }}"
   when: not devstack
-  notify: restart the forum service when failover fails
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -27,6 +27,43 @@
     - install
     - install:configuration
 
+- name: create the watchdog config
+  template:
+    src: watchdog.conf.j2
+    dest: "{{ supervisor_available_dir }}/watchdog.conf"
+    owner: "{{ supervisor_user }}"
+    group: "{{ supervisor_user }}"
+    mode: 0644
+  become_user: "{{ supervisor_user }}"
+  tags:
+    - install
+    - install:configuration
+
+- name: enable the watchdog config
+  file:
+    src: "{{ supervisor_available_dir }}/watchdog.conf"
+    dest: "{{ supervisor_cfg_dir }}/watchdog.conf"
+    owner: "{{ supervisor_user }}"
+    state: link
+    force: yes
+    mode: 0644
+  become_user: "{{ supervisor_user }}"
+  when: not disable_edx_services
+  tags:
+    - install
+    - install:configuration
+
+- name: configure the watchdog script
+  template:
+    src: "{{ forum_watchdog|basename }}.j2"
+    dest: "{{ forum_watchdog }}"
+    mode: 0755
+  become_user: "{{ forum_user }}"
+  notify: restart the forum service when failover fails
+  tags:
+    - install
+    - install:configuration
+
 - name: create the supervisor wrapper
   template:
     src: "{{ forum_supervisor_wrapper|basename }}.j2"

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -39,7 +39,7 @@
   tags:
     - install
     - install:configuration
-    - forum-watchdog
+    - install:forum-watchdog
 
 - name: enable the watchdog config
   file:
@@ -54,7 +54,7 @@
   tags:
     - install
     - install:configuration
-    - forum-watchdog
+    - install:forum-watchdog
 
 - name: configure the watchdog script
   template:
@@ -66,7 +66,7 @@
   tags:
     - install
     - install:configuration
-    - forum-watchdog
+    - install:forum-watchdog
 
 - name: create the supervisor wrapper
   template:
@@ -138,6 +138,7 @@
   tags:
     - manage
     - manage:update
+    - install:forum-watchdog
 
 - name: ensure forum is started
   supervisorctl:

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -39,6 +39,7 @@
   tags:
     - install
     - install:configuration
+    - forum-watchdog
 
 - name: enable the watchdog config
   file:
@@ -53,6 +54,7 @@
   tags:
     - install
     - install:configuration
+    - forum-watchdog
 
 - name: configure the watchdog script
   template:
@@ -64,6 +66,7 @@
   tags:
     - install
     - install:configuration
+    - forum-watchdog
 
 - name: create the supervisor wrapper
   template:

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -150,6 +150,17 @@
   tags:
     - manage
 
+- name: ensure watchdog is started
+  supervisorctl:
+    name: forum-watchdog
+    supervisorctl_path: "{{ supervisor_ctl }}"
+    config: "{{ supervisor_cfg }}"
+    state: started
+  when: not disable_edx_services
+  tags:
+    - manage
+    - install:forum-watchdog
+
 - include: test.yml
   tags:
     - deploy

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -30,7 +30,7 @@
 - name: create the watchdog config
   template:
     src: watchdog.conf.j2
-    dest: "{{ supervisor_available_dir }}/watchdog.conf"
+    dest: "{{ supervisor_available_dir }}/forum-watchdog.conf"
     owner: "{{ supervisor_user }}"
     group: "{{ supervisor_user }}"
     mode: 0644
@@ -43,8 +43,8 @@
 
 - name: enable the watchdog config
   file:
-    src: "{{ supervisor_available_dir }}/watchdog.conf"
-    dest: "{{ supervisor_cfg_dir }}/watchdog.conf"
+    src: "{{ supervisor_available_dir }}/forum-watchdog.conf"
+    dest: "{{ supervisor_cfg_dir }}/forum-watchdog.conf"
     owner: "{{ supervisor_user }}"
     state: link
     force: yes
@@ -156,7 +156,7 @@
     supervisorctl_path: "{{ supervisor_ctl }}"
     config: "{{ supervisor_cfg }}"
     state: started
-  when: not disable_edx_services
+  when: not disable_edx_services and not devstack
   tags:
     - manage
     - install:forum-watchdog

--- a/playbooks/roles/forum/templates/forum-watchdog.sh.j2
+++ b/playbooks/roles/forum/templates/forum-watchdog.sh.j2
@@ -1,16 +1,10 @@
 #!/bin/bash
 
-{% if ! devstack %}
-  tail -f {{ supervisor_log_dir }}/forum-stderr.log |
-  grep --line-buffered 'Mongo::Error::OperationFailure - not master and slaveOk=false (13435)' |
-  while read;
-  do
-    dt=`date '+%d/%m/%Y %H:%M:%S'`
-    echo "[$dt] Forum Failure detected - Restarting forum service..."
-    {{ supervisor_ctl }} restart forum
-  done
-{ % else %}
-  # On devstack just run a dummy loop to keep supervisor from trying to
-  # restart service
-  while true; do sleep 1d; done
-{% endif %}
+tail -f {{ supervisor_log_dir }}/forum-stderr.log |
+grep --line-buffered 'Mongo::Error::OperationFailure - not master and slaveOk=false (13435)' |
+while read
+do
+  dt=`date '+%d/%m/%Y %H:%M:%S'`
+  echo "[$dt] Forum Failure detected - Restarting forum service..."
+  {{ supervisor_ctl }} restart forum
+done

--- a/playbooks/roles/forum/templates/forum-watchdog.sh.j2
+++ b/playbooks/roles/forum/templates/forum-watchdog.sh.j2
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "[$dt] Forum WatchDog service started"
+
 tail -f {{ supervisor_log_dir }}/forum-stderr.log |
 grep --line-buffered 'Mongo::Error::OperationFailure - not master and slaveOk=false (13435)' |
 while read

--- a/playbooks/roles/forum/templates/forum-watchdog.sh.j2
+++ b/playbooks/roles/forum/templates/forum-watchdog.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+{% if ! devstack %}
+  tail -f {{ supervisor_log_dir }}/forum-stderr.log |
+  grep --line-buffered 'Mongo::Error::OperationFailure - not master and slaveOk=false (13435)' |
+  while read;
+  do
+    dt=`date '+%d/%m/%Y %H:%M:%S'`
+    echo "[$dt] Forum Failure detected - Restarting forum service..."
+    {{ supervisor_ctl }} restart forum
+  done
+{ % else %}
+  # On devstack just run a dummy loop to keep supervisor from trying to
+  # restart service
+  while true; do sleep 1d; done
+{% endif %}

--- a/playbooks/roles/forum/templates/forum-watchdog.sh.j2
+++ b/playbooks/roles/forum/templates/forum-watchdog.sh.j2
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+dt=`date '+%d/%m/%Y %H:%M:%S'`
 echo "[$dt] Forum WatchDog service started"
 
 tail -f {{ supervisor_log_dir }}/forum-stderr.log |

--- a/playbooks/roles/forum/templates/watchdog.conf.j2
+++ b/playbooks/roles/forum/templates/watchdog.conf.j2
@@ -1,0 +1,9 @@
+[program:forum-watchdog]
+command={{ forum_watchdog }}
+priority=999
+user={{ common_web_user }}
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
+killasgroup=true
+stopasgroup=true
+stopsignal=QUIT


### PR DESCRIPTION
Configuration Pull Request
---
This PR adds a watchdog for the forum service that restarts it every time it fails to recover from a MongoDB failover when using replica sets.

**Testing instructions:**
1. Deploy a server with this branch
2. Check that the discussions session is working on LMS
3. Perform the failover (you might have to do this more than one, since the bug happens randomly)
4. Refresh the LMS discussion page, when you get an error, the script will be triggered and restart the service.
5. Check the logs to see if the script ran correctly: `tail /edx/var/log/supervisor/forum-watchdog-stdout.log`. You should see:
```
[15/01/2019 13:10:42] Forum WatchDog service started
[15/01/2019 13:15:50] Forum Failure detected - Restarting forum service...
```
6. Refresh the discussion page again, the error should be gone.

**Checklist:**

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
