### PR TITLE
BB-834: Fix simple theme to look more consistent regards coloring

### DIFF
--- a/playbooks/roles/simple_theme/defaults/main.yml
+++ b/playbooks/roles/simple_theme/defaults/main.yml
@@ -57,6 +57,7 @@ simpletheme_folder: "{{ EDXAPP_COMPREHENSIVE_THEME_DIRS.0 }}/{{ EDXAPP_DEFAULT_S
 #     value: '#07f'
 #
 SIMPLETHEME_SASS_OVERRIDES: []
+SIMPLETHEME_SASS_BOOTSTRAP_OVERRIDES: []
 
 # Files from the specified directory will be copied to the static/ directory.
 # This is mainly designed to include images and JS.

--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_extras.scss
@@ -1,0 +1,9 @@
+// Extra rules needed for the LMS red theme
+//
+// The _extras.scss file is imported after all other rules by
+// the LMS Sass. For your own theme, you can override this file
+// to add any custom rules that you need. You can also import
+// partials directly into this file so that you can break your
+// rules into modular pieces.
+
+@import '../lms-overrides';

--- a/playbooks/roles/simple_theme/tasks/deploy.yml
+++ b/playbooks/roles/simple_theme/tasks/deploy.yml
@@ -91,6 +91,7 @@
   with_items:
     # List of files from ./templates to be processed
     - "lms/static/sass/partials/lms/theme/_variables-v1.scss"
+    - "lms/static/sass/partials/lms/theme/_variables.scss"
     - "lms/static/sass/_lms-overrides.scss"
 
 # Copying static files is done in two steps: create directories + copy files

--- a/playbooks/roles/simple_theme/templates/lms/static/sass/partials/lms/theme/_variables.scss.j2
+++ b/playbooks/roles/simple_theme/templates/lms/static/sass/partials/lms/theme/_variables.scss.j2
@@ -1,0 +1,7 @@
+/* Variables from simple_theme role start here */
+{% for item in SIMPLETHEME_SASS_BOOTSTRAP_OVERRIDES %}
+${{ item.variable }}: {{ item.value }};
+{% endfor %}
+/* Variables from simple_theme role end here */
+
+@import 'lms/static/sass/partials/lms/theme/variables';


### PR DESCRIPTION
This PR adds support in `simple-theme` to override views themed using bootstrap, such as the Courseware and Discussion pages.

**Reviewers:**
- [ ] @lgp171188 

Configuration Pull Request
---
Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
