### PR TITLE
BB-987: Fix deployment bug

### DIFF
--- a/playbooks/roles/oauth_client_setup/defaults/main.yml
+++ b/playbooks/roles/oauth_client_setup/defaults/main.yml
@@ -72,7 +72,7 @@ oauth_client_setup_oauth2_clients:
         username: "{{ EDXAPP_VEDA_SERVICE_USER_NAME | default('None') }}"
       }
     - {
-        name: "{{ retirement_service_name | default('None') }}",
+        name: "{{ retirement_service_name if RETIREMENT_SERVICE_SETUP|default(false)|bool else 'None' }}",
         backend_service_id: "{{ RETIREMENT_SERVICE_OAUTH_CLIENT_ID | default('None') }}",
         backend_service_secret: "{{ RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET | default('None') }}",
         username: "{{ RETIREMENT_SERVICE_USER_NAME | default('None') }}",


### PR DESCRIPTION
This PR fixes a small bug that happened when the retirement service wasn't provisioned. The scripts tried to register an OAuth Application but the retirement user wasn't provisioned. 
The fix is a default value for avoiding the provisioning the retirement worker credentials unless explicitly set.

**Testing instructions:**
1. Clone the repo on `src/` of your devstack and checkout this branch.
2. Set up the environment:
```
$ make lms-shell
export PYTHONUNBUFFERED=1
source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
cd /edx/src/configuration/playbooks
```
3. Run: 
```
export PYTHONUNBUFFERED=1
source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
cd /edx/src/configuration/playbooks
ansible-playbook \
  -i localhost, \
  -c local run_role.yml \
  -e role=oauth_client_setup \
  -e configuration_version=master \
  -e edx_platform_version=master \
  -e edxapp_user=root \
  -e RETIREMENT_SERVICE_SETUP=true \
  -e RETIREMENT_SERVICE_USER_NAME=retirement_service_worker \
  -e retirement_service_name="retirement_service_worker" \
  -e RETIREMENT_SERVICE_OAUTH_CLIENT_ID=id \
  -e RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET=secret
```
You should see a fatal error indicating that some variables are missing, that's fine.
5. Run:
```
ansible-playbook \
  -i localhost, \
  -c local run_role.yml \
  -e role=oauth_client_setup \
  -e configuration_version=master \
  -e edx_platform_version=master \
  -e edxapp_user=root \
  -e RETIREMENT_SERVICE_SETUP=false \
  -e RETIREMENT_SERVICE_USER_NAME=retirement_service_worker \
  -e retirement_service_name="retirement_service_worker" \
  -e RETIREMENT_SERVICE_OAUTH_CLIENT_ID=id \
  -e RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET=secret
```
You'll see that the user provisioning has been skipped:
```
skipping: [localhost] => (item={u'username': u'retirement_service_worker', u'backend_service_secret': u'secret', u'name': u'None', u'backend_service_id': u'id'})
```
5. Run:
```
ansible-playbook \
  -i localhost, \
  -c local run_role.yml \
  -e role=oauth_client_setup \
  -e configuration_version=master \
  -e edx_platform_version=master \
  -e edxapp_user=root \
  -e RETIREMENT_SERVICE_USER_NAME=retirement_service_worker \
  -e retirement_service_name="retirement_service_worker" \
  -e RETIREMENT_SERVICE_OAUTH_CLIENT_ID=id \
  -e RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET=secret
```
You'll see that the user provisioning has been skipped:
```
skipping: [localhost] => (item={u'username': u'retirement_service_worker', u'backend_service_secret': u'secret', u'name': u'None', u'backend_service_id': u'id'})
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
