### PR TITLE
Add Insights configuration for Hawthorn

### DIFF
--- a/playbooks/analytics_sandbox.yml
+++ b/playbooks/analytics_sandbox.yml
@@ -1,0 +1,35 @@
+---
+- name: Bootstrap instance(s)
+  hosts: all
+  gather_facts: no
+  become: True
+  roles:
+    - python
+
+- name: Deploy analytics related services (except the pipeline)
+  hosts: all
+  become: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+    disable_edx_services: false
+    ENABLE_DATADOG: False
+    ENABLE_SPLUNKFORWARDER: False
+    ENABLE_NEWRELIC: False
+  roles:
+    - aws
+    - security
+    - mysql
+    - edxlocal
+    - analytics_api
+    - role: nginx
+      nginx_sites:
+        - insights
+    - insights
+    - role: postfix_queue
+      when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
+  tasks:
+    - name: 'Install libffi-dev'
+      apt: name=libffi-dev state=present
+    - name: 'Install make'
+      apt: name=make state=present

--- a/playbooks/analytics_sandbox.yml
+++ b/playbooks/analytics_sandbox.yml
@@ -19,8 +19,6 @@
   roles:
     - aws
     - security
-    - mysql
-    - edxlocal
     - analytics_api
     - role: nginx
       nginx_sites:


### PR DESCRIPTION
This adds a playbook for configuring analytics. This was previously in the ginkgo branch, but when we switched to hawthorn it wasn't carried over.
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
