### PR TITLE
[BB-1208] Ironwood preparation changes

### DIFF
--- a/playbooks/analytics_sandbox.yml
+++ b/playbooks/analytics_sandbox.yml
@@ -1,0 +1,37 @@
+---
+- name: Bootstrap instance(s)
+  hosts: all
+  gather_facts: no
+  become: True
+  roles:
+    - python
+
+- name: Deploy analytics related services (except the pipeline)
+  hosts: all
+  become: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+    disable_edx_services: false
+    ENABLE_DATADOG: False
+    ENABLE_SPLUNKFORWARDER: False
+    ENABLE_NEWRELIC: False
+  roles:
+    - aws
+    - security
+    - common_vars
+    - role: nginx
+      nginx_sites:
+        - insights
+    - analytics_api
+    - role: nginx
+      nginx_sites:
+        - analytics_api
+    - insights
+    - role: postfix_queue
+      when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
+  tasks:
+    - name: 'Install libffi-dev'
+      apt: name=libffi-dev state=present
+    - name: 'Install make'
+      apt: name=make state=present

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
@@ -1,0 +1,60 @@
+upstream analytics_api_app_server {
+    {% for host in nginx_analytics_api_gunicorn_hosts %}
+        server {{ host }}:{{ analytics_api_gunicorn_port }} fail_timeout=0;
+    {% endfor %}
+}
+
+server {
+  listen {{ ANALYTICS_API_NGINX_PORT }} default_server;
+
+  # Nginx does not support nested condition or or conditions so
+  # there is an unfortunate mix of conditonals here.
+  {% if NGINX_REDIRECT_TO_HTTPS %}
+     {% if NGINX_HTTPS_REDIRECT_STRATEGY == "scheme" %}
+  # Redirect http to https over single instance
+  if ($scheme != "https")
+  {
+   set $do_redirect_to_https "true";
+  }
+
+    {% elif NGINX_HTTPS_REDIRECT_STRATEGY == "forward_for_proto" %}
+
+  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB
+  if ($http_x_forwarded_proto = "http")
+  {
+   set $do_redirect_to_https "true";
+  }
+     {% endif %}
+
+  # Execute the actual redirect
+  if ($do_redirect_to_https = "true")
+  {
+  return 301 https://$host$request_uri;
+  }
+  {% endif %}
+
+  location ~ ^/static/(?P<file>.*) {
+    root {{ COMMON_DATA_DIR }}/{{ analytics_api_service_name }};
+    try_files /staticfiles/$file =404;
+  }
+
+  location / {
+    try_files $uri @proxy_to_app;
+  }
+
+  {% include "robots.j2" %}
+
+location @proxy_to_app {
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
+    proxy_set_header Host $http_host;
+
+    proxy_redirect off;
+    proxy_pass http://analytics_api_app_server;
+  }
+}


### PR DESCRIPTION
Configuration Pull Request
---
This PR ports the changes from the hawthorn branch which have not been upstreamed and have to be carried forward to ironwood. The PR is against the branch which will be made the `epodx` branch before the upgrade.

* Adds the `analytics_sandbox.yml` playbook and the nginx configuration template for the `analytics_api` app.

Additionally, it includes a change to optionally disable the demo role from being run.
Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
