### PR TITLE
Cherry Pick ecommerce repo overrides into ironwood branch

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -13,6 +13,15 @@
 
 ECOMMERCE_GIT_IDENTITY: !!null
 
+ECOMMERCE_REPOS:
+  - PROTOCOL: '{{ COMMON_GIT_PROTOCOL }}'
+    DOMAIN: '{{ COMMON_GIT_MIRROR }}'
+    PATH: '{{ COMMON_GIT_PATH }}'
+    REPO: 'ecommerce.git'
+    VERSION: 'master'
+    DESTINATION: "{{ ecommerce_code_dir }}"
+    SSH_KEY: null
+
 # depends upon Newrelic being enabled via COMMON_ENABLE_NEWRELIC
 # and a key being provided via NEWRELIC_LICENSE_KEY
 ECOMMERCE_NEWRELIC_APPNAME: "{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-{{ ecommerce_service_name }}"

--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -18,9 +18,9 @@ ECOMMERCE_REPOS:
     DOMAIN: '{{ COMMON_GIT_MIRROR }}'
     PATH: '{{ COMMON_GIT_PATH }}'
     REPO: 'ecommerce.git'
-    VERSION: 'master'
+    VERSION: '{{ ECOMMERCE_VERSION }}'
     DESTINATION: "{{ ecommerce_code_dir }}"
-    SSH_KEY: null
+    SSH_KEY: '{{ ECOMMERCE_GIT_IDENTITY }}'
 
 # depends upon Newrelic being enabled via COMMON_ENABLE_NEWRELIC
 # and a key being provided via NEWRELIC_LICENSE_KEY

--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -21,6 +21,7 @@ dependencies:
     edx_django_service_config_overrides: '{{ ecommerce_service_config_overrides }}'
     edx_django_service_debian_pkgs_extra: '{{ ecommerce_debian_pkgs }}'
     edx_django_service_django_settings_module: '{{ ECOMMERCE_DJANGO_SETTINGS_MODULE }}'
+    edx_django_service_repos: '{{ ECOMMERCE_REPOS }}'
     edx_django_service_environment_extra: '{{ ecommerce_environment }}'
     edx_django_service_gunicorn_extra: '{{ ECOMMERCE_GUNICORN_EXTRA }}'
     edx_django_service_gunicorn_port: '{{ ecommerce_gunicorn_port }}'


### PR DESCRIPTION
This PR just cherry picks a few commits that allow us to override the ecommerce repository using `ECOMMERCE_REPOS`. These are already upstreamed into `edx:master`, but did not make it into their ironwood configuration release.
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
