### PR TITLE
[BB-1294] Wait for cloud-init to complete before trying to run 'apt' commands

### DIFF
--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -12,8 +12,17 @@
 - debug:
     var: python_update_result
 
+- name: Search for python-minimal
+  become: true
+  raw: apt-cache search python-minimal
+  register: search_result
+
+- name: Debug search for python-minimal
+  debug:
+    var: search_result
+
 - name: Install packages
-  raw: "apt-get install {{ item }}"
+  raw: "apt-get install -y {{ item }}"
   with_items: "{{ python_packages }}"
   register: apt_install
 

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -2,8 +2,12 @@
 # xenial+ cloud images don't have python2.7 installed, and ansible doesn't yet
 # support python3.
 
+- name: Populate service facts
+  service_facts:
+
 - name: Wait until cloud-init has finished running
   raw: cloud-init status --wait
+  when: "'cloud-init.target' in ansible_facts.services"
 
 - name: Update apt-get
   raw: apt-get update -qq

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -3,12 +3,18 @@
 # support python3.
 
 - name: Update apt-get
-  raw: apt-get update -qq
+  raw: apt-get update
   register: python_update_result
-  until: python_update_result.rc == 0
   retries: 10
   delay: 10
 
+- debug:
+    var: python_update_result
+
 - name: Install packages
-  raw: "apt-get install -qq {{ item }}"
+  raw: "apt-get install {{ item }}"
   with_items: "{{ python_packages }}"
+  register: apt_install
+
+- debug:
+    var: apt_install

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -2,38 +2,16 @@
 # xenial+ cloud images don't have python2.7 installed, and ansible doesn't yet
 # support python3.
 
-- name: Print repos
-  become: true
-  raw: cat /etc/apt/sources.list | grep -v -e '#' -e '^$'
-  register: repos_output
-
-- name: Debug repos
-  debug:
-    var: repos_output
+- name: Wait until cloud-init has finished running
+  raw: cloud-init status --wait
 
 - name: Update apt-get
-  become: true
-  raw: apt-get update
+  raw: apt-get update -qq
   register: python_update_result
+  until: python_update_result.rc == 0
   retries: 10
   delay: 10
 
-- debug:
-    var: python_update_result
-
-- name: Search for python-minimal
-  become: true
-  raw: apt-cache search python-minimal
-  register: search_result
-
-- name: Debug search for python-minimal
-  debug:
-    var: search_result
-
 - name: Install packages
-  raw: "apt-get install -y {{ item }}"
+  raw: "apt-get install -qq {{ item }}"
   with_items: "{{ python_packages }}"
-  register: apt_install
-
-- debug:
-    var: apt_install

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -2,12 +2,14 @@
 # xenial+ cloud images don't have python2.7 installed, and ansible doesn't yet
 # support python3.
 
-- name: Populate service facts
-  service_facts:
+- name: Check if the cloud-init command is installed
+  stat:
+    path: /usr/bin/cloud-init
+  register: cloud_init_command
 
 - name: Wait until cloud-init has finished running
   raw: cloud-init status --wait
-  when: "'cloud-init.target' in ansible_facts.services"
+  when: cloud_init_command.stat.exists
 
 - name: Update apt-get
   raw: apt-get update -qq

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -2,13 +2,9 @@
 # xenial+ cloud images don't have python2.7 installed, and ansible doesn't yet
 # support python3.
 
-- name: Check if the cloud-init command is installed
-  command: test -e /usr/bin/cloud-init
-  register: cloud_init_command
-
 - name: Wait until cloud-init has finished running
-  raw: cloud-init status --wait
-  when: cloud_init_command.rc == 0
+  raw: test -e /usr/bin/cloud-init && cloud-init status --wait
+  ignore_errors: yes
 
 - name: Update apt-get
   raw: apt-get update -qq

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -3,6 +3,7 @@
 # support python3.
 
 - name: Update apt-get
+  become: true
   raw: apt-get update
   register: python_update_result
   retries: 10

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -3,13 +3,12 @@
 # support python3.
 
 - name: Check if the cloud-init command is installed
-  stat:
-    path: /usr/bin/cloud-init
+  command: test -e /usr/bin/cloud-init
   register: cloud_init_command
 
 - name: Wait until cloud-init has finished running
   raw: cloud-init status --wait
-  when: cloud_init_command.stat.exists
+  when: cloud_init_command.rc == 0
 
 - name: Update apt-get
   raw: apt-get update -qq

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -2,6 +2,15 @@
 # xenial+ cloud images don't have python2.7 installed, and ansible doesn't yet
 # support python3.
 
+- name: Print repos
+  become: true
+  raw: cat /etc/apt/sources.list | grep -v -e '#' -e '^$'
+  register: repos_output
+
+- name: Debug repos
+  debug:
+    var: repos_output
+
 - name: Update apt-get
   become: true
   raw: apt-get update


### PR DESCRIPTION
Configuration Pull Request
---

Due to the `apt` tasks in the `python` role running before `cloud-init` finishes (which also updates the `sources.list` file), the `python-minimal` package is not found and that causes the provisioning to fail. This PR adds a check to wait for `cloud-init` to complete before proceeding further.

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
