### PR TITLE
[BB-1294] Wait for cloud-init to complete before trying to run 'apt' …

### DIFF
--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -2,6 +2,10 @@
 # xenial+ cloud images don't have python2.7 installed, and ansible doesn't yet
 # support python3.
 
+- name: Wait until cloud-init has finished running
+  raw: test -e /usr/bin/cloud-init && cloud-init status --wait
+  ignore_errors: yes
+
 - name: Update apt-get
   raw: apt-get update -qq
   register: python_update_result


### PR DESCRIPTION
…commands (#99)

This fixes the error about being unable to find the 'python-minimal' package as the 'cloud-init' processs changes the '/etc/apt/sources.list' file soon after the VM boots up.

Needed to use this branch to upgrade MAW instance.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
