### PR TITLE
BB-184 Modify gunicorn template for more granular gunicorn control 

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -589,7 +589,18 @@ EDXAPP_CODE_JAIL_LIMITS:
 # EDXAPP_WORKERS:
 #   lms: <num workers>
 #   cms: <num workers>
+# EDXAPP_WORKER_THREADS
+#   lms: <num worker threads>
+#   cms: <num worker threads>
 EDXAPP_WORKERS: !!null
+EDXAPP_WORKER_THREADS: !!null
+EDXAPP_WORKER_CLASS: !!null
+# Gunicorn will restart each worker after x amount of
+# requests processed. The x value will be randomly selected between
+# 1 and this value (default 1500)
+EDXAPP_WORKER_MAX_REQUEST_JITTER: 1500
+EDXAPP_ANALYTICS_DATA_TOKEN: ""
+EDXAPP_ANALYTICS_DATA_URL: ""
 # Dashboard URL, assumes that the insights role is installed locally
 EDXAPP_ANALYTICS_DASHBOARD_URL: "http://localhost:18110/courses"
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -598,7 +598,8 @@ EDXAPP_WORKER_CLASS: !!null
 # Gunicorn will restart each worker after x amount of
 # requests processed. The x value will be randomly selected between
 # 1 and this value (default 1500)
-EDXAPP_WORKER_MAX_REQUEST_JITTER: 1500
+EDXAPP_CMS_MAX_REQUEST_JITTER: 1500
+EDXAPP_LMS_MAX_REQUEST_JITTER: 1500
 EDXAPP_ANALYTICS_DATA_TOKEN: ""
 EDXAPP_ANALYTICS_DATA_URL: ""
 # Dashboard URL, assumes that the insights role is installed locally

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -588,7 +588,7 @@ EDXAPP_CODE_JAIL_LIMITS:
 # Should be set to
 EDXAPP_WORKERS:
   lms: 14
-  cms: 14
+  cms: 4
 # EDXAPP_WORKER_THREADS
 #   lms: <num worker threads>
 #   cms: <num worker threads>

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -586,9 +586,9 @@ EDXAPP_CODE_JAIL_LIMITS:
 
 # Set the number of workers explicitly for lms and cms
 # Should be set to
-# EDXAPP_WORKERS:
-#   lms: <num workers>
-#   cms: <num workers>
+EDXAPP_WORKERS:
+  lms: 14
+  cms: 14
 # EDXAPP_WORKER_THREADS
 #   lms: <num worker threads>
 #   cms: <num worker threads>

--- a/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
@@ -17,7 +17,16 @@ max_requests = {{ EDXAPP_CMS_MAX_REQ }}
 {% if EDXAPP_WORKERS %}
 workers = {{ EDXAPP_WORKERS.cms }}
 {% else %}
-workers = (multiprocessing.cpu_count()-1) * {{ worker_core_mult.cms }} + {{ worker_core_mult.cms }}
+workers = multiprocessing.cpu_count() * {{ worker_core_mult.cms }}
+{% endif %}
+{% if EDXAPP_WORKER_THREADS %}
+threads = {{ EDXAPP_WORKER_THREADS.cms }}
+{% endif %}
+{% if EDXAPP_WORKER_CLASS %}
+worker_class = {{ EDXAPP_WORKER_CLASS }}
+{% endif %}
+{% if EDXAPP_WORKER_MAX_REQUEST_JITTER %}
+max_requests_jitter = {{ EDXAPP_WORKER_MAX_REQUEST_JITTER }}
 {% endif %}
 
 {{ common_pre_request }}

--- a/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
@@ -10,9 +10,11 @@ timeout = {{ EDXAPP_CMS_GUNICORN_TIMEOUT }}
 bind = "{{ edxapp_cms_gunicorn_host }}:{{ edxapp_cms_gunicorn_port }}"
 pythonpath = "{{ edxapp_code_dir }}"
 
-{% if EDXAPP_CMS_MAX_REQ -%}
+{% if EDXAPP_CMS_MAX_REQ %}
 max_requests = {{ EDXAPP_CMS_MAX_REQ }}
-{% endif -%}
+{% elif EDXAPP_CMS_MAX_REQUEST_JITTER %}
+max_requests_jitter = {{ EDXAPP_CMS_MAX_REQUEST_JITTER }}
+{% endif %}
 
 {% if EDXAPP_WORKERS %}
 workers = {{ EDXAPP_WORKERS.cms }}
@@ -24,9 +26,6 @@ threads = {{ EDXAPP_WORKER_THREADS.cms }}
 {% endif %}
 {% if EDXAPP_WORKER_CLASS %}
 worker_class = {{ EDXAPP_WORKER_CLASS }}
-{% endif %}
-{% if EDXAPP_WORKER_MAX_REQUEST_JITTER %}
-max_requests_jitter = {{ EDXAPP_WORKER_MAX_REQUEST_JITTER }}
 {% endif %}
 
 {{ common_pre_request }}

--- a/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
@@ -17,8 +17,19 @@ max_requests = {{ EDXAPP_LMS_MAX_REQ }}
 {% if EDXAPP_WORKERS %}
 workers = {{ EDXAPP_WORKERS.lms }}
 {% else %}
-workers = (multiprocessing.cpu_count()-1) * {{ worker_core_mult.lms }} + {{ worker_core_mult.lms }}
+workers = multiprocessing.cpu_count() * {{ worker_core_mult.lms }}
 {% endif %}
+{% if EDXAPP_WORKER_THREADS %}
+threads = {{ EDXAPP_WORKER_THREADS.lms }}
+{% endif %}
+{% if EDXAPP_WORKER_CLASS %}
+worker_class = {{ EDXAPP_WORKER_CLASS }}
+{% endif %}
+{% if EDXAPP_WORKER_MAX_REQUEST_JITTER %}
+max_requests_jitter = {{ EDXAPP_WORKER_MAX_REQUEST_JITTER }}
+{% endif %}
+
+
 
 {{ common_pre_request }}
 

--- a/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
@@ -10,9 +10,11 @@ timeout = {{ EDXAPP_LMS_GUNICORN_TIMEOUT }}
 bind = "{{ edxapp_lms_gunicorn_host }}:{{ edxapp_lms_gunicorn_port }}"
 pythonpath = "{{ edxapp_code_dir }}"
 
-{% if EDXAPP_LMS_MAX_REQ -%}
+{% if EDXAPP_LMS_MAX_REQ %}
 max_requests = {{ EDXAPP_LMS_MAX_REQ }}
-{% endif -%}
+{% elif EDXAPP_LMS_MAX_REQUEST_JITTER %}
+max_requests_jitter = {{ EDXAPP_LMS_MAX_REQUEST_JITTER }}
+{% endif %}
 
 {% if EDXAPP_WORKERS %}
 workers = {{ EDXAPP_WORKERS.lms }}
@@ -24,9 +26,6 @@ threads = {{ EDXAPP_WORKER_THREADS.lms }}
 {% endif %}
 {% if EDXAPP_WORKER_CLASS %}
 worker_class = {{ EDXAPP_WORKER_CLASS }}
-{% endif %}
-{% if EDXAPP_WORKER_MAX_REQUEST_JITTER %}
-max_requests_jitter = {{ EDXAPP_WORKER_MAX_REQUEST_JITTER }}
 {% endif %}
 
 


### PR DESCRIPTION
Configuration Pull Request
---

This PR updates the `workers` formula to improve readability. The formula used to read `(cpus - 1) * mul + mul` where `cpus` is the number of cpus and `mul` is a multiplier which value is set in the yaml variables. If we expand this formula we can simplify it to `cpus * mul`:
```
(cpus - 1) * mul + mul
(mul * cpus) - mul + mul
mul * cpus
```
This PR also adds three more gunicorn config variables:
[threads](http://docs.gunicorn.org/en/stable/settings.html#threads) : This will allow us to use multiple threads for each worker. Making it possible to run more workers and keeping gunicorn memory footprint low.
[worker_class](http://docs.gunicorn.org/en/stable/settings.html#worker-class) : If `threads` are used then it is possible to specify which type of thread class gunicorn will use. By default it will use `gthread` if any number of `threads` if specified.
[max_requests_jitter](http://docs.gunicorn.org/en/stable/settings.html#max-requests-jitter) : This will allow us to specify a max number of requests before gunicorn restart a worker. By doing this we help handle any memory leak happening in the application.

Reasoning:

We have experimented with a different amount of workers as well as max requests before gunicorn restart the workers. Using a number around 14 of workers have helped us better use all the resources in different cases. This is why we suggest adding gunicorn's `thread` and `worker_class` that way other users can run more workers while keeping gunicorn's memory footprint almost the same. Using 14 `sync` workers ( the default type of workers without threads) also works perfectly, hence using `threads` and `worker_class` is completely optional.
We've also added the `max_requests_jitter` configuration so users can specify how many requests will each worker handle before being restarted by gunicorn. This has allowed us to avoid memory leak or high memory consumption by one or multiple workers in different cases. We usually use `max_request` but in the latest gunicorn they've introduced `max_request_jitter` which will make gunicorn use a random number of max request between 0 and this value. This avoids having all threads restart at the same time and make the application sluggish.

**Note:** Once this is approved we have to create another PR for current hawthorn instances if we want to use this across the board. Also, we should use a `EDXAPP_WORKERS` value of 14 as default.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
