### PR TITLE
Add a 'pre' requirements file for the sandbox

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1537,6 +1537,7 @@ base_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/base.txt"
 django_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/django.txt"
 openstack_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/openstack.txt"
 
+sandbox_pre_requirements: "{{ edxapp_code_dir }}/requirements/edx-sandbox/pre.txt"
 sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/base.txt"
 
 # The Python requirements files in the order they should be installed.  This order should

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -271,12 +271,15 @@
 - name: code sandbox | Install base sandbox requirements and create sandbox virtualenv
   pip:
     chdir: "{{ edxapp_code_dir }}"
-    requirements: "{{ sandbox_base_requirements }}"
+    requirements: "{{ item }}"
     virtualenv: "{{ edxapp_sandbox_venv_dir }}"
     state: present
     extra_args: "-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w"
   become_user: "{{ edxapp_sandbox_user }}"
   when: EDXAPP_PYTHON_SANDBOX
+  with_items:
+    - "{{ sandbox_pre_requirements }}"
+    - "{{ sandbox_base_requirements }}"
   tags:
     - edxapp-sandbox
     - install


### PR DESCRIPTION
'matplotlib' requires 'numpy' to be already installed. Otherwise it tries
to download the latest version which is incompatible with Python
2.7. So this adds changes to install the 'pre' requirements file
before installing the sandbox requirements.

Has to be tested with https://github.com/open-craft/edx-platform/pull/175.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
