### PR TITLE
Move the SASS variables to a common file

### DIFF
--- a/playbooks/roles/simple_theme/tasks/deploy.yml
+++ b/playbooks/roles/simple_theme/tasks/deploy.yml
@@ -90,6 +90,7 @@
     group: "{{ common_web_group }}"
   with_items:
     # List of files from ./templates to be processed
+    - "lms/static/sass/common-variables.scss"
     - "lms/static/sass/partials/lms/theme/_variables-v1.scss"
     - "lms/static/sass/_lms-overrides.scss"
 

--- a/playbooks/roles/simple_theme/templates/lms/static/sass/_lms-overrides.scss.j2
+++ b/playbooks/roles/simple_theme/templates/lms/static/sass/_lms-overrides.scss.j2
@@ -1,4 +1,4 @@
+@import 'common-variables';
 /* Extra SASS as defined by simple_theme starts here: */
 {{ SIMPLETHEME_EXTRA_SASS }}
 /* Extra SASS as defined by simple_theme ends here. */
-

--- a/playbooks/roles/simple_theme/templates/lms/static/sass/common-variables.scss.j2
+++ b/playbooks/roles/simple_theme/templates/lms/static/sass/common-variables.scss.j2
@@ -1,0 +1,5 @@
+/* Variables from simple_theme role start here */
+{% for item in SIMPLETHEME_SASS_OVERRIDES %}
+${{ item.variable }}: {{ item.value }};
+{% endfor %}
+/* Variables from simple_theme role end here */

--- a/playbooks/roles/simple_theme/templates/lms/static/sass/partials/lms/theme/_variables-v1.scss.j2
+++ b/playbooks/roles/simple_theme/templates/lms/static/sass/partials/lms/theme/_variables-v1.scss.j2
@@ -1,8 +1,2 @@
-/* Variables from simple_theme role start here */
-{% for item in SIMPLETHEME_SASS_OVERRIDES %}
-${{ item.variable }}: {{ item.value }};
-{% endfor %}
-/* Variables from simple_theme role end here */
-
-@import 'lms/static/sass/partials/lms/theme/variables-v1'; 
-
+@import '../common-variables';
+@import 'lms/static/sass/partials/lms/theme/variables-v1';


### PR DESCRIPTION
This allows the variables to be used in the bootstrap and
non-bootstrap styles.

These changes are required for https://github.com/open-craft/edx-simple-theme/pull/2 and have been tested in the sandboxes used for demonstrating the high-level simple theme.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
