### PR TITLE
[BB-1619] Fix failover issue in forum service

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -11,6 +11,7 @@ forum_supervisor_wrapper: "{{ forum_app_dir }}/forum-supervisor.sh"
 forum_gem_root: "{{ forum_rbenv_dir }}/.gem"
 forum_gem_bin: "{{ forum_gem_root }}/bin"
 forum_path: "{{ forum_binstubs_dir }}:{{ forum_rbenv_bin }}:{{ forum_rbenv_shims }}:{{ forum_gem_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+forum_watchdog: "{{ forum_app_dir }}/forum-watchdog.sh"
 
 FORUM_MONGO_USER: "cs_comments_service"
 FORUM_MONGO_PASSWORD: "password"

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -27,6 +27,47 @@
     - install
     - install:configuration
 
+- name: create the watchdog config
+  template:
+    src: watchdog.conf.j2
+    dest: "{{ supervisor_available_dir }}/forum-watchdog.conf"
+    owner: "{{ supervisor_user }}"
+    group: "{{ supervisor_user }}"
+    mode: 0644
+  become_user: "{{ supervisor_user }}"
+  when: not devstack
+  tags:
+    - install
+    - install:configuration
+    - install:forum-watchdog
+
+- name: enable the watchdog config
+  file:
+    src: "{{ supervisor_available_dir }}/forum-watchdog.conf"
+    dest: "{{ supervisor_cfg_dir }}/forum-watchdog.conf"
+    owner: "{{ supervisor_user }}"
+    state: link
+    force: yes
+    mode: 0644
+  become_user: "{{ supervisor_user }}"
+  when: not disable_edx_services and not devstack
+  tags:
+    - install
+    - install:configuration
+    - install:forum-watchdog
+
+- name: configure the watchdog script
+  template:
+    src: "{{ forum_watchdog|basename }}.j2"
+    dest: "{{ forum_watchdog }}"
+    mode: 0755
+  become_user: "{{ forum_user }}"
+  when: not devstack
+  tags:
+    - install
+    - install:configuration
+    - install:forum-watchdog
+
 - name: create the supervisor wrapper
   template:
     src: "{{ forum_supervisor_wrapper|basename }}.j2"
@@ -97,6 +138,7 @@
   tags:
     - manage
     - manage:update
+    - install:forum-watchdog
 
 - name: ensure forum is started
   supervisorctl:
@@ -107,6 +149,17 @@
   when: not disable_edx_services
   tags:
     - manage
+
+- name: ensure watchdog is started
+  supervisorctl:
+    name: forum-watchdog
+    supervisorctl_path: "{{ supervisor_ctl }}"
+    config: "{{ supervisor_cfg }}"
+    state: started
+  when: not disable_edx_services and not devstack
+  tags:
+    - manage
+    - install:forum-watchdog
 
 - include: test.yml
   tags:

--- a/playbooks/roles/forum/templates/forum-watchdog.sh.j2
+++ b/playbooks/roles/forum/templates/forum-watchdog.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+dt=`date '+%d/%m/%Y %H:%M:%S'`
+echo "[$dt] Forum WatchDog service started"
+
+tail -f {{ supervisor_log_dir }}/forum-stderr.log |
+grep --line-buffered 'Mongo::Error::OperationFailure - not master and slaveOk=false (13435)' |
+while read
+do
+  dt=`date '+%d/%m/%Y %H:%M:%S'`
+  echo "[$dt] Forum Failure detected - Restarting forum service..."
+  {{ supervisor_ctl }} restart forum
+done

--- a/playbooks/roles/forum/templates/watchdog.conf.j2
+++ b/playbooks/roles/forum/templates/watchdog.conf.j2
@@ -1,0 +1,9 @@
+[program:forum-watchdog]
+command={{ forum_watchdog }}
+priority=999
+user={{ common_web_user }}
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
+killasgroup=true
+stopasgroup=true
+stopsignal=QUIT


### PR DESCRIPTION
Description
=========

This PR adds a watchdog for the forum service that restarts it every time it fails to recover from a MongoDB failover when using replica sets.

Testing
----------

1. Checkout this branch and deploy the forum playbook `forum.yml` to the devstack:
```
$ ansible-playbook -vvv -i hosts playbooks/forum.yml -e "disable_edx_services=true"
```

2. Check the forum-watchdog files have been installed correcly:
```
/edx/app/forum/forum-watchdog.sh
/edx/app/supervisor/conf.available.d/forum-watchdog.conf
```

3. Watch the forum-watchdog log file to make sure it has been started:
```
$ tail -f /edx/var/log/supervisor/forum-watchdog-stdout.log
```

4. Trigger the watchdog:
```
$ echo "Mongo::Error::OperationFailure - not master and slaveOk=false (13435)" >> /edx/var/log/supervisor/forum-stderr.log
```

5. Make sure the watchdog restarts the forum service:
```
[28/08/2019 20:02:56] Forum WatchDog service started
[28/08/2019 20:35:19] Forum Failure detected - Restarting forum service...
forum: stopped
forum: started
```