### PR TITLE
[BB-2222] Increase LMS client_max_body_size

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -65,13 +65,13 @@ server {
 
   {% if NGINX_EDXAPP_ENABLE_S3_MAINTENANCE %}
 
-  # Do not include a 502 error in NGINX_ERROR_PAGES when 
+  # Do not include a 502 error in NGINX_ERROR_PAGES when
   # NGINX_EDXAPP_ENABLE_S3_MAINTENANCE is enabled.
 
   error_page 502 @maintenance;
 
     {% include "s3_maintenance.j2" %}
-  
+
   {% endif %}
 
   # error pages
@@ -107,14 +107,14 @@ error_page {{ k }} {{ v }};
 
 
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}
-  
+
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
   error_log {{ nginx_log_dir }}/error.log error;
 
-  # CS184 requires uploads of up to 4MB for submitting screenshots.
-  # CMS requires larger value for course assest, values provided
+  # Latest devices with high resolution webcam requires uploads of up to 10MB for submitting
+  # software secure photos. CMS requires larger value for course assets, values provided
   # via hiera.
-  client_max_body_size 4M;
+  client_max_body_size 10M;
 
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -111,10 +111,10 @@ error_page {{ k }} {{ v }};
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
   error_log {{ nginx_log_dir }}/error.log error;
 
-  # Latest devices with high resolution webcam requires uploads of up to 10MB for submitting
-  # software secure photos. CMS requires larger value for course assets, values provided
+  # Some Master's courses require submissions up to 20MB in size.
+  # CMS requires larger value for course assets, values provided
   # via hiera.
-  client_max_body_size 10M;
+  client_max_body_size 20M;
 
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
 


### PR DESCRIPTION
This cherry-picks changes from 719db300be4245109d98490761b3bfbaccbfc12e and edx#5399.

It's a clean cherry-pick from upstream, which doesn't alter LMS behavior without modifying `STUDENT_FILEUPLOAD_MAX_SIZE` (cf.  edx/edx-platform#21589), so we don't need to review this.
