### PR TITLE
[BB-2438] Override additional partials and the discussion bootstrap styles

### DIFF
--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/discussion/lms-discussion-bootstrap.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/discussion/lms-discussion-bootstrap.scss
@@ -1,0 +1,2 @@
+@import 'lms/static/sass/discussion/lms-discussion-bootstrap';
+@import '../lms-overrides';

--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_variables-v1.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_variables-v1.scss
@@ -1,0 +1,2 @@
+@import '../common-variables';
+@import 'lms/static/sass/partials/lms/theme/variables-v1';

--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_variables.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_variables.scss
@@ -1,0 +1,2 @@
+@import '../common-variables';
+@import 'lms/static/sass/partials/lms/theme/variables';

--- a/playbooks/roles/simple_theme/tasks/deploy.yml
+++ b/playbooks/roles/simple_theme/tasks/deploy.yml
@@ -91,7 +91,6 @@
   with_items:
     # List of files from ./templates to be processed
     - "lms/static/sass/common-variables.scss"
-    - "lms/static/sass/partials/lms/theme/_variables-v1.scss"
     - "lms/static/sass/_lms-overrides.scss"
 
 # Copying static files is done in two steps: create directories + copy files


### PR DESCRIPTION
This fixes the issues where some styles were not getting applied to the bootstrap pages.

**Testing instructions**:
* Deploy the simple-theme using this PR branch
* Verify that the bootstrap pages are themed properly - for example the discussion pages, courseware pages etc.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
