### PR TITLE
Remove repeated data dir creation step

### DIFF
--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -27,7 +27,6 @@
     - { path: "{{ edxapp_theme_dir }}" }
     - { path: "{{ edxapp_staticfile_dir }}" }
     - { path: "{{ edxapp_course_static_dir }}" }
-    - { path: "{{ edxapp_course_data_dir }}" }
     # var should have more permissive permissions than the rest
     - { path: "{{ edxapp_data_dir }}", mode: "0775" }
     # directory to import the courses from github


### PR DESCRIPTION
This PR removes the ambigous step of creating course data dir with different owner permission. While running the edxapp role, course data dir get initially created with `edxapp:www-data` owner:group permission and then changes to `www-data:edxapp` in a later step. Course data dir needs to have `www-data` as owner inorder to be able to access the course. This removes the first step and only retains the second one where the permissions are `www-data:edxapp`.

**Jira Ticket:**
[SE-2987](https://tasks.opencraft.com/browse/SE-2987)

**Testing Instructions:**
1. Spawn a new instance using this branch (I already created a [test instance](https://manage.opencraft.com/instance/20410/edx-appserver/13454/) and created a course in it).
2. Verify course data dir (i.e. /edx/var/edxapp/data) is created with the correct owner permission.
3. Create a sample course and verify that it can accessed.

**Reviewers:**
- [ ] @mavidser 
