### PR TITLE
Attempting to turn off setuputils distlib override (#5978) (Ironwood)

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -25,6 +25,7 @@ ANALYTICS_API_DJANGO_SETTINGS_MODULE: "analyticsdataserver.settings.production"
 analytics_api_environment:
   ANALYTICS_API_CFG: "{{ COMMON_CFG_DIR }}/{{ analytics_api_service_name }}.yml"
   DJANGO_SETTINGS_MODULE: "{{ ANALYTICS_API_DJANGO_SETTINGS_MODULE }}"
+  SETUPTOOLS_USE_DISTUTILS: "stdlib" # https://setuptools.readthedocs.io/en/latest/history.html#v50-0-0
 
 analytics_api_home: "{{ COMMON_APP_DIR }}/{{ analytics_api_service_name }}"
 analytics_api_user: "{{ analytics_api_service_name }}"

--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -36,6 +36,7 @@ edx_django_service_node_version: '{{ common_node_version }}'
 edx_django_service_environment_default:
   DJANGO_SETTINGS_MODULE: '{{ edx_django_service_django_settings_module }}'
   PATH: '{{ edx_django_service_nodeenv_bin }}:{{ edx_django_service_venv_dir }}/bin:{{ ansible_env.PATH }}'
+  SETUPTOOLS_USE_DISTUTILS: "stdlib" # https://setuptools.readthedocs.io/en/latest/history.html#v50-0-0
 edx_django_service_environment_extra: {}
 edx_django_service_environment: '{{ edx_django_service_environment_default | combine(edx_django_service_environment_extra) }}'
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1013,6 +1013,7 @@ edxapp_environment_default:
   LMS_CFG: "{{ edxapp_lms_cfg }}"
   STUDIO_CFG: "{{ edxapp_studio_cfg }}"
   BOTO_CONFIG: "{{ edxapp_app_dir }}/.boto"
+  SETUPTOOLS_USE_DISTUTILS: "stdlib" # https://setuptools.readthedocs.io/en/latest/history.html#v50-0-0
 
 edxapp_environment_extra: {}
 

--- a/playbooks/roles/xqueue/tasks/main.yml
+++ b/playbooks/roles/xqueue/tasks/main.yml
@@ -96,6 +96,7 @@
     DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"
     DB_MIGRATION_PASS: "{{ COMMON_MYSQL_MIGRATE_PASS }}"
     XQUEUE_CFG: '{{ COMMON_CFG_DIR }}/xqueue.yml'
+    SETUPTOOLS_USE_DISTUTILS: "stdlib" # https://setuptools.readthedocs.io/en/latest/history.html#v50-0-0
   when: migrate_db is defined and migrate_db|lower == "yes" and COMMON_MYSQL_MIGRATE_PASS
   run_once: yes
   tags:
@@ -107,6 +108,7 @@
   become_user: "{{ xqueue_user }}"
   environment:
     XQUEUE_CFG: '{{ COMMON_CFG_DIR }}/xqueue.yml'
+    SETUPTOOLS_USE_DISTUTILS: "stdlib" # https://setuptools.readthedocs.io/en/latest/history.html#v50-0-0
   when: not disable_edx_services
   tags:
     - manage

--- a/playbooks/roles/xqueue/templates/xqueue.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue.conf.j2
@@ -11,7 +11,7 @@ command={{ executable }} -c {{ xqueue_app_dir }}/xqueue_gunicorn.py {{ XQUEUE_GU
 user={{ common_web_user }}
 directory={{ xqueue_code_dir }}
 
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQUEUE_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}PID=/var/tmp/xqueue.pid,PORT={{ xqueue_gunicorn_port }},ADDRESS={{ xqueue_gunicorn_host }},LANG={{ XQUEUE_LANG }},DJANGO_SETTINGS_MODULE=xqueue.{{ XQUEUE_SETTINGS }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQUEUE_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}PID=/var/tmp/xqueue.pid,PORT={{ xqueue_gunicorn_port }},ADDRESS={{ xqueue_gunicorn_host }},LANG={{ XQUEUE_LANG }},DJANGO_SETTINGS_MODULE=xqueue.{{ XQUEUE_SETTINGS }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml,SETUPTOOLS_USE_DISTUTILS="stdlib"
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log

--- a/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
@@ -11,7 +11,7 @@ command={{ executable }} --pythonpath={{ xqueue_code_dir }} --settings=xqueue.{{
 user={{ common_web_user }}
 directory={{ xqueue_code_dir }}
 
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_STARTUP_TIMEOUT=10,NEW_RELIC_APP_NAME={{ XQUEUE_CONSUMER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}LANG={{ XQUEUE_LANG }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_STARTUP_TIMEOUT=10,NEW_RELIC_APP_NAME={{ XQUEUE_CONSUMER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}LANG={{ XQUEUE_LANG }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml,SETUPTOOLS_USE_DISTUTILS="stdlib"
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log


### PR DESCRIPTION
Configuration Pull Request
---

This PR cherry-picks the fix for `setuptools==50.0` onto ironwood.2 branch

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
