### PR TITLE
Fix determining video storage location

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -875,7 +875,7 @@ EDXAPP_VIDEO_IMAGE_SETTINGS:
   VIDEO_IMAGE_MAX_BYTES : 2097152
   VIDEO_IMAGE_MIN_BYTES : 2048
   STORAGE_KWARGS:
-    location: "{{ edxapp_media_dir_s3 }}/"
+    location: "{{ edxapp_video_storage_location }}/"
     base_url: "{{ EDXAPP_MEDIA_URL }}/"
   DIRECTORY_PREFIX: 'video-images/'
 
@@ -885,7 +885,7 @@ EDXAPP_VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
 EDXAPP_VIDEO_TRANSCRIPTS_SETTINGS:
   VIDEO_TRANSCRIPTS_MAX_BYTES : 3145728
   STORAGE_KWARGS:
-    location: "{{ edxapp_media_dir_s3 }}/"
+    location: "{{ edxapp_video_storage_location }}/"
     base_url: "{{ EDXAPP_MEDIA_URL }}/"
   DIRECTORY_PREFIX: 'video-transcripts/'
 
@@ -1037,6 +1037,7 @@ edxapp_deploy_path: "{{ edxapp_venv_bin }}:{{ edxapp_code_dir }}/bin:{{ edxapp_n
 edxapp_staticfile_dir: "{{ edxapp_data_dir }}/staticfiles"
 edxapp_media_dir: "{{ edxapp_data_dir }}/media"
 edxapp_media_dir_s3: "{{ edxapp_media_dir | regex_replace('^\\/', '') }}"
+edxapp_video_storage_location: "{% if EDXAPP_DEFAULT_FILE_STORAGE == 'django.core.files.storage.FileSystemStorage' %}{{ edxapp_media_dir }}{% else %}{{ edxapp_media_dir_s3 }}{% endif %}/"
 edxapp_course_static_dir: "{{ edxapp_data_dir }}/course_static"
 edxapp_course_data_dir: "{{ edxapp_data_dir }}/data"
 edxapp_upload_dir: "{{ edxapp_data_dir }}/uploads"


### PR DESCRIPTION
Based on the `EDXAPP_DEFAULT_FILE_STORAGE` determine which `edxapp_media_dir` should be used. In case the storage is a file system storage, use the default media dir with the leading slash (`edxapp_media_dir`), otherwise use the S3 based one (`edxapp_media_dir_s3`) without leading slash.

Upstream PR: https://github.com/edx/configuration/pull/6014

**Discussions**: 

* [GitHub PR introduced the issue](https://github.com/edx/configuration/pull/5789#issuecomment-689131337)

**Dependencies**: None

**Screenshots**: 
![Screenshot 2020-09-18 at 14 25 14](https://user-images.githubusercontent.com/19173947/93597320-25681480-f9bb-11ea-8c52-d14e520d9d75.png)


**Sandbox URL**: https://se-3316.stage.opencraft.hosting/ (credentials: the default demo staff user credentials)

**Merge deadline**: None

**Testing instructions**:

1. Create a course
2. Add video
3. Add transcript

You can use the following content for transcript:

```
1
00:00:00,00 --> 00:01:00,00
Hello, this is working fine
```

**Author notes and concerns**:

1. In case there is a third storage type beside Local File System Storage and S3, and the new storage type requires a leading slash, the media upload will fail. - I don't think this will be an issue in the near future