### PR TITLE
SE-3327 Certificate validation for intermediate certificate download

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -20,6 +20,7 @@
   get_url:
     url: "{{ common_digicert_base_url }}/{{ common_digicert_name }}.pem"
     dest: "/usr/local/share/ca-certificates/{{ common_digicert_name }}"
+    validate_certs: yes
   when: update_ca_certificates is defined and update_ca_certificates.results[0].stat.exists == True
 
 - name: Update CA Certificates

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -55,7 +55,7 @@ COMMON_NPM_MIRROR_URL: 'https://registry.npmjs.org'
 COMMON_UBUNTU_APT_KEYSERVER: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search="
 
 common_digicert_name: "DigiCertSHA2SecureServerCA.crt"
-common_digicert_base_url: "https://dl.cacerts.digicert.com/"
+common_digicert_base_url: "https://cacerts.digicert.com/"
 
 COMMON_EDX_PPA: "deb http://ppa.edx.org {{ ansible_distribution_release }} main"
 COMMON_EDX_PPA_KEY_SERVER: "keyserver.ubuntu.com"


### PR DESCRIPTION
(cherry picked from commit 5426d5dff98a88c74f267fcb94d1f3c248231140) - source: https://github.com/edx/configuration/pull/5852

Original author's description:

> Ansible "validate_certs" for ´get_url´ function needs to be turned on for any servers reached via the public Internet. This was likely turned off due to using a faulty certificate delivery server which itself had her trust chain broken. Changed the url to a properly configured certificate distribution server.

**Test instructions**:

- provision an instance on an ubuntu server
- verify it successfully completes the download and update ca certificates steps (ie. the digicert correctly downloaded and update-ca-certificates is run.

**Reviewers**:

- [ ] @bradenmacdonald 