### PR TITLE
Remove AppleId third party backend from defaults

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -208,7 +208,6 @@ EDXAPP_THIRD_PARTY_AUTH_BACKENDS:
   - social_core.backends.linkedin.LinkedinOAuth2
   - social_core.backends.facebook.FacebookOAuth2
   - social_core.backends.azuread.AzureADOAuth2
-  - third_party_auth.appleid.AppleIdAuth
   - third_party_auth.identityserver3.IdentityServer3
   - third_party_auth.saml.SAMLAuthBackend
   - third_party_auth.lti.LTIAuthBackend


### PR DESCRIPTION
Configuration Pull Request
---

This fixes an issue introduced in #136 from a backported default variable mistakenly including `third_party_auth.appleid.AppleIdAuth` in `THIRD_PARTY_AUTH_BACKENDS` which is unavailable in Juniper.