### PR TITLE
[SE-3381] Clears existing node modules before installing npm dependencies

### DIFF
--- a/playbooks/roles/tinymce_adsk_plugin/defaults/main.yml
+++ b/playbooks/roles/tinymce_adsk_plugin/defaults/main.yml
@@ -8,8 +8,6 @@ tinymce_adsk_plugin_temp_dir: "{{ edxapp_code_dir }}/.temp_tinymce_adsk_plugin"
 tinymce_dir: "{{ edxapp_code_dir }}/common/static/js/vendor/tinymce"
 tinymce_plugins_dir: "{{ tinymce_dir }}/js/tinymce/plugins"
 
-tinymce_adsk_plugin_minified_js_path: "{{ tinymce_plugins_dir }}/{{ tinymce_adsk_plugin_dir_name }}/plugin.min.js"
-
 edx_jake_package: "{{ edxapp_code_dir }}/vendor_extra/tinymce/JakePackage.zip"
 
 tinymce_themes:

--- a/playbooks/roles/tinymce_adsk_plugin/tasks/main.yml
+++ b/playbooks/roles/tinymce_adsk_plugin/tasks/main.yml
@@ -30,8 +30,8 @@
       shell: "npm install"
       args:
         chdir: "{{ tinymce_dir }}"
-    - name: Clean existing tinymce files with jake
-      shell: "npx jake clean"
+    - name: Clean existing tinymce js files with jake
+      shell: "npx jake clean-js"
       args:
         chdir: "{{ tinymce_dir }}"
     - name: Build tinymce with jake

--- a/playbooks/roles/tinymce_adsk_plugin/tasks/main.yml
+++ b/playbooks/roles/tinymce_adsk_plugin/tasks/main.yml
@@ -26,10 +26,6 @@
         src: "{{ edx_jake_package }}"
         dest: "{{ tinymce_dir }}"
         remote_src: yes
-    - name: Installs npm dependencies from archive
-      shell: "npm install"
-      args:
-        chdir: "{{ tinymce_dir }}"
     - name: Build tinymce with jake
       shell: "npx jake minify bundle[themes:{{ tinymce_themes | join(',') }},plugins:{{ tinymce_plugins | join(',') }}]"
       args:

--- a/playbooks/roles/tinymce_adsk_plugin/tasks/main.yml
+++ b/playbooks/roles/tinymce_adsk_plugin/tasks/main.yml
@@ -13,10 +13,6 @@
       file:
         state: absent
         path: "{{ tinymce_adsk_plugin_temp_dir }}"
-    - name: Remove minified plugin javascript
-      file:
-        state: absent
-        path: "{{ tinymce_adsk_plugin_minified_js_path }}"
   become_user: "{{ edxapp_user }}"
 
 - name: Minify tinymce plugin files
@@ -26,6 +22,10 @@
         src: "{{ edx_jake_package }}"
         dest: "{{ tinymce_dir }}"
         remote_src: yes
+    - name: Clean existing tinymce files with jake
+      shell: "npx jake clean"
+      args:
+        chdir: "{{ tinymce_dir }}"
     - name: Build tinymce with jake
       shell: "npx jake minify bundle[themes:{{ tinymce_themes | join(',') }},plugins:{{ tinymce_plugins | join(',') }}]"
       args:

--- a/playbooks/roles/tinymce_adsk_plugin/tasks/main.yml
+++ b/playbooks/roles/tinymce_adsk_plugin/tasks/main.yml
@@ -22,6 +22,14 @@
         src: "{{ edx_jake_package }}"
         dest: "{{ tinymce_dir }}"
         remote_src: yes
+    - name: Clean existing node modules
+      file:
+        state: absent
+        path: "{{ tinymce_dir }}/node_modules"
+    - name: Install npm dependencies from archive
+      shell: "npm install"
+      args:
+        chdir: "{{ tinymce_dir }}"
     - name: Clean existing tinymce files with jake
       shell: "npx jake clean"
       args:


### PR DESCRIPTION
After the latest changes on the edx-platform regarding `JakePackage.zip`, the `node_modules` needs to be cleared, so that the npm dependencies can install successfully without any error. Also the existing minified files need to be cleaned too using `npx jake clean-js` so that we always generate new minified files.

Related to PR: https://github.com/open-craft/edx-platform/pull/275

**JIRA tickets**: SE-3381, SE-3101

**Testing instructions**:

1. Launch a new instance with this configuration branch
2. Make sure that the `adsklink` plugin works in Studio in TinyMCE editor
3. Change directory to `edx-platform/common/static/js/vendor/tinymce`
4. Verify all `plugin.min.js` were generated correctly using: `grep -Er "^undefined$"`
5. Verify that `commons.js` file hash is consistent on different machines

**Author notes and concerns**:

1. Instances were already spawned on Autodesk Upskill STG.
2. I think it would be a good idea to include a private key for Ansible to retrieve the repository from GitHub directly, but I'll get started on that at the end of the sprint.

**Reviewers**
- [ ] @pkulkark 