### PR TITLE
[BB-3112] Pin `setuptools` in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ MySQL-python==1.2.5
 #Azure:
 azure==2.0.0
 azure-storage==0.20.0
+
+setuptools==44.1.1


### PR DESCRIPTION
Installing requirements using the default version of setuptools (`45.0.0`) is not working anymore.