### PR TITLE
[SE-3405] Add GDPR endpoint to nginx

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -290,6 +290,10 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  location /v1/accounts/gdpr_retire_users {
+    try_files $uri @proxy_to_lms_app;
+  }
+
 location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
     root {{ edxapp_media_dir }};
     try_files /$file =404;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -290,6 +290,7 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  # No basic auth, uses oauth2 for authentication
   location /v1/accounts/gdpr_retire_users {
     try_files $uri @proxy_to_lms_app;
   }


### PR DESCRIPTION
This PR adds an nginx entry for the gdpr user retirement api introduced in [open-craft/edx-platform#300](https://github.com/open-craft/edx-platform/pull/300). Without this entry, nginx will reject the api requests made.

**Dependencies:**
-  [open-craft/edx-platform#300](https://github.com/open-craft/edx-platform/pull/300)

**Sandbox URL:** TBD

**Testing Instructions:**
See testing instructions in [open-craft/edx-platform#300](https://github.com/open-craft/edx-platform/pull/300)

**Reviewers:**
- [ ] @mavidser

