### PR TITLE
[SE-3856] Cherry picks the internal code drift from juniper 3 used by Autodesk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
+ 
+ - 2021-01-08
+     - Role: tinymce_plugins
+        - Installs `tinymce_plugins` specified in `TINYMCE_ADDITIONAL_PLUGINS_LIST` configuration variable
+        - Rebuilds TinyMCE files with the newly installed plugins and the previous ones
+
+     - Role: edxapp
+        - Includes `tinymce_plugins` role in order to install custom TinyMCE plugins, if there are any.
+
+ - 2021-01-05
+     - Role: edxapp
+        - setting `proxy_buffer_size` behind the EDXAPP_SET_PROXY_BUFFER_SIZE flag.
+
+ - 2020-12-11
+    - Role: jenkins_master
+       - Adding variable/tasks to create directories for job virtual
+         enviroments to be created, as part of removing shiningpanda
+         as a dependency.
+
+ - 2020-12-09
+     - Role: edxapp
+        - Updated renderer options to reference `common.djangoapps.edxmako`
+          instead of `edxmako`. The latter import path is deprecated.
+          Other than removing warnings, there should be no functional
+          change.
+
+ - 2020-12-02
+    - Role: mfe
+        - Added logo-related configuration settings, with defaults.
 
  - 2020-12-01
     - Role: edxapp

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -364,6 +364,12 @@
     - install
     - install:configuration
 
+- name: import custom tinymce plugins
+  include_role:
+    name: "tinymce_plugins"
+  when:
+    - celery_worker is not defined
+
 # creates the supervisor jobs for the
 # service variants configured, runs
 # gather_assets and db migrations

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -286,6 +286,11 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  # No basic auth, uses oauth2 for authentication
+  location /v1/accounts/gdpr_retire_users {
+    try_files $uri @proxy_to_lms_app;
+  }
+
 location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
     root {{ edxapp_media_dir }};
     try_files /$file =404;

--- a/playbooks/roles/tinymce_plugins/README.rst
+++ b/playbooks/roles/tinymce_plugins/README.rst
@@ -1,0 +1,47 @@
+TinyMCE (Visual Text/HTML Editor) Plugins
+-----------------------------------------
+
+The flexibility of the TinyMCE Visual Text and HTML editor makes it possible to configure and extend the editor using different plugins. In order to make use of that modularity in Studio, you'll need to follow two different steps.
+
+Installing Plugins
+==================
+
+In order to install the needed TinyMCE plugins while setting up the edX platform, you'll need to specify them in ``TINYMCE_ADDITIONAL_PLUGINS_LIST``. It is a list of objects with the following attributes:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 10 10 65
+
+   * - attribute
+     - type
+     - required
+     - description
+   * - ``repo``
+     - string
+     - yes
+     - The TinyMCE plugin's repository.
+   * - ``name``
+     - string
+     - yes
+     - Specifies the name of the cloned repository for the TinyMCE plugin.
+   * - ``plugin_path``
+     - string
+     - no
+     - Specifies the plugin's relative path in the repository. It is the directory that directly contains the ``plugin.js`` file.
+       Default value is ``/``, which indicates that the repository directly contains the ``plugin.js`` file. If the repository doesn't directly contain the ``plugin.js``, then the folder containing it should share the same name as the plugin name.
+
+Here's an example:
+
+.. code:: yaml
+
+   TINYMCE_ADDITIONAL_PLUGINS_LIST:
+   - repo: https://github.com/name/demo-plugin
+     name: demo-plugin
+     plugin_path: "/demo-plugin"
+
+Enabling Plugins
+================
+
+There's a decent `guide on enabling the plugins through the edX platform`_, specifically using the ``TINYMCE_ADDITIONAL_PLUGINS`` extra JavaScript configuration.
+
+.. _guide on enabling the plugins through the edX platform: https://github.com/edx/edx-platform/blob/master/docs/guides/extensions/tinymce_plugins.rst

--- a/playbooks/roles/tinymce_plugins/defaults/main.yml
+++ b/playbooks/roles/tinymce_plugins/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+
+tinymce_plugin_temp_dir: "{{ edxapp_code_dir }}/.temp_tinymce_plugin"
+
+tinymce_dir: "{{ edxapp_code_dir }}/common/static/js/vendor/tinymce"
+tinymce_plugins_dir: "{{ tinymce_dir }}/js/tinymce/plugins"
+
+edx_jake_package: "{{ edxapp_code_dir }}/vendor_extra/tinymce/JakePackage.zip"
+
+TINYMCE_ADDITIONAL_PLUGINS_LIST: []

--- a/playbooks/roles/tinymce_plugins/tasks/import_tinymce_plugin.yml
+++ b/playbooks/roles/tinymce_plugins/tasks/import_tinymce_plugin.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Add additional tinymce plugins
+  block:
+    - name: Clone plugin
+      git:
+        repo: "{{ plugin.repo }}"
+        dest: "{{ tinymce_plugin_temp_dir }}/{{ plugin.name }}"
+        version: "{{ plugin.version | default('master') }}"
+        accept_hostkey: true
+        key_file: "{% if EDXAPP_USE_GIT_IDENTITY %}{{ edxapp_git_identity }}{% endif %}"
+    - name: Move plugin to tinymce plugins directory
+      command: "cp -r {{ tinymce_plugin_temp_dir }}/{{ plugin.name }}{{ plugin.plugin_path | default('') }} {{ tinymce_plugins_dir }}"
+    - name: Clean temporary tinymce plugin repository
+      file:
+        state: absent
+        path: "{{ tinymce_plugin_temp_dir }}/{{ plugin.name }}"
+  become_user: "{{ edxapp_user }}"

--- a/playbooks/roles/tinymce_plugins/tasks/main.yml
+++ b/playbooks/roles/tinymce_plugins/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Import additional tinymce plugins
+  include_tasks: import_tinymce_plugin.yml
+  loop: "{{ TINYMCE_ADDITIONAL_PLUGINS_LIST }}"
+  loop_control:
+    loop_var: plugin
+  when:
+    - TINYMCE_ADDITIONAL_PLUGINS_LIST|length > 0
+
+- name: Rebuild tinymce files
+  include_tasks: rebuild_tinymce_files.yml
+  when:
+    - TINYMCE_ADDITIONAL_PLUGINS_LIST|length > 0

--- a/playbooks/roles/tinymce_plugins/tasks/rebuild_tinymce_files.yml
+++ b/playbooks/roles/tinymce_plugins/tasks/rebuild_tinymce_files.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Minify tinymce plugin files
+  block:
+    - name: Unarchive JakePackage.zip
+      unarchive:
+        src: "{{ edx_jake_package }}"
+        dest: "{{ tinymce_dir }}"
+        remote_src: True
+    - name: Clean install npm dependencies from archive
+      shell: "npm ci"
+      args:
+        chdir: "{{ tinymce_dir }}"
+    - name: Clean existing tinymce js files with jake
+      shell: "npx jake clean-js"
+      args:
+        chdir: "{{ tinymce_dir }}"
+    - name: Build tinymce with jake
+      shell: "npx jake minify bundle[themes:*,plugins:*]"
+      args:
+        chdir: "{{ tinymce_dir }}"
+  become_user: "{{ edxapp_user }}"


### PR DESCRIPTION
This pull request is exactly identical to #147 

It is reopened because we need to merge, without "squashing".

---

Cherry picks the [internal juniper 3 code drift](https://github.com/edx/configuration/compare/open-release/juniper.3...open-craft:opencraft-release/juniper.3) used by Autodesk

**JIRA tickets**: SE-3856

**Sandbox URL**:
- LMS: https://www.autodesk-koa.stage.opencraft.hosting/
- Studio: https://studio.autodesk-koa.stage.opencraft.hosting/

**Testing instructions**:

1. Follow the testing instructions from the pull requests linked in SE-3856

**Author notes and concerns**:

1. Some of the pull requests were included in Koa, they are also mentioned in SE-3856
2. **Please don't squash and merge**, it is important that those cherry-picked commits are mentioned explicitly

**Reviewers**
- [ ] @0x29a 

---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
