### PR TITLE
[BB-3518] Merge in remaining code drift from opencraft-release/juniper.3 in opencraft-release/koa.1

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -221,7 +221,6 @@ EDXAPP_THIRD_PARTY_AUTH_BACKENDS:
   - social_core.backends.linkedin.LinkedinOAuth2
   - social_core.backends.facebook.FacebookOAuth2
   - social_core.backends.azuread.AzureADOAuth2
-  - third_party_auth.appleid.AppleIdAuth
   - third_party_auth.identityserver3.IdentityServer3
   - third_party_auth.saml.SAMLAuthBackend
   - third_party_auth.lti.LTIAuthBackend


### PR DESCRIPTION
This PR contains code drift that wasn't merged to the https://github.com/edx/configuration repo or wasn't included into `koa.1` or `koa.2` release. 

**JIRA tickets**:
- [BB-3518](https://tasks.opencraft.com/browse/BB-3518)

**Dependencies**:
https://github.com/open-craft/edx-platform/pull/316
https://github.com/open-craft/ecommerce/pull/18

**Sandbox URL**:
https://bb-3518.stage.opencraft.hosting/ (https://stage.manage.opencraft.com/instance/7110/)

**Testing instructions**:

Go through the test instructions from every PR that is marked as "To cherry-pick" in [this document](https://gist.github.com/0x29a/d14186fb07578d82d669056400c83782). Use sandbox for testing. 

**Reviewers**

- [x] @nizarmah 

**Settings**
```yaml
DEMO_CREATE_STAFF_USER: false
SANDBOX_ENABLE_CERTIFICATES: false
demo_test_users: []

EDXAPP_FEATURES:
  ENABLE_EDXNOTES: true

# Append to any existing EDXAPP_LMS_ENV_EXTRA:
EDXAPP_LMS_ENV_EXTRA:
  COURSE_MODE_DEFAULTS:
    bulk_sku: !!null
    currency: gbp
    description: !!null
    expiration_datetime: !!null
    min_price: 0
    name: Honor
    sku: !!null
    slug: honor
    suggested_prices: ''

# prevent creating example partners; this isn't required, and will cause provision errors later
ecommerce_create_demo_data: false

SANDBOX_ENABLE_DISCOVERY: yes
SANDBOX_ENABLE_ECOMMERCE: yes
DISCOVERY_VERSION: "{{ ECOMMERCE_VERSION }}"
DISCOVERY_MYSQL_REPLICA_HOST: "{{DISCOVERY_MYSQL}}"

COMMON_HOSTNAME: ""

# Have to build the full broker URLs to ensure the vhost path is included
ECOMMERCE_BROKER_URL: '{{ EDXAPP_CELERY_BROKER_TRANSPORT }}://{{ EDXAPP_CELERY_USER }}:{{ EDXAPP_CELERY_PASSWORD }}@{{ EDXAPP_CELERY_BROKER_HOSTNAME }}{{ EDXAPP_CELERY_BROKER_VHOST }}'
ECOMMERCE_WORKER_BROKER_URL: '{{ EDXAPP_CELERY_BROKER_TRANSPORT }}://{{ EDXAPP_CELERY_USER }}:{{ EDXAPP_CELERY_PASSWORD }}@{{ EDXAPP_CELERY_BROKER_HOSTNAME }}{{ EDXAPP_CELERY_BROKER_VHOST }}'
ECOMMERCE_WORKER_ECOMMERCE_API_ROOT: '{{ ECOMMERCE_ECOMMERCE_URL_ROOT }}/api/v2/'

EDXAPP_PAID_COURSE_REGISTRATION_CURRENCY: ['gbp', '£']
ECOMMERCE_OSCAR_DEFAULT_CURRENCY: 'GBP'
ECOMMERCE_REPOS:
  - PROTOCOL: '{{ COMMON_GIT_PROTOCOL }}'
    DOMAIN: '{{ COMMON_GIT_MIRROR }}'
    PATH: 'open-craft'
    REPO: 'ecommerce.git'
    # Use a branch which contains this fix:
    # https://github.com/open-craft/ecommerce/pull/13/files
    VERSION: 0x29a/merge_remaining_code_drift
    DESTINATION: "{{ ecommerce_code_dir }}"
    SSH_KEY: '{{ ECOMMERCE_GIT_IDENTITY }}'

# must add as root cronjob, even though we want to run the task as the discovery user, because these cronjobs are added before the discovery user is created.
EDXAPP_ADDITIONAL_CRON_JOBS:
- name: "discovery: hourly course metadata refresh"
  user: "root"
  job: "sudo -u discovery bash -c 'source {{ discovery_home }}/discovery_env; {{ COMMON_BIN_DIR }}/manage.discovery refresh_course_metadata'"
  hour: "*"
  minute: "43"
  day: "*"
```