### PR TITLE
[BB-4082] Pin edx/tubular to fix issue with installation of incompatible version of `cryptography`

### DIFF
--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -40,6 +40,15 @@
     ECOMMERCE_ENABLE_COMPREHENSIVE_THEMING: false
     EDXAPP_ENABLE_MEMCACHE: true
     EDXAPP_ENABLE_ELASTIC_SEARCH: true
+    # See https://chat.opencraft.com/opencraft/pl/gycakygo1fyxfc5zmwx1jb67na
+    RETIREMENT_SERVICE_GIT_REPOS:
+      - PROTOCOL: "{{ COMMON_GIT_PROTOCOL }}"
+        DOMAIN: "{{ COMMON_GIT_MIRROR }}"
+        PATH: "{{ COMMON_GIT_PATH }}"
+        REPO: "tubular.git"
+        VERSION: "24beaac052467e3e85627d4b16f4ee5ee33b42d2"
+        DESTINATION: "{{ retirement_service_app_dir }}"
+        SSH_KEY: "{{ RETIREMENT_SERVICE_GIT_IDENTITY }}"
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB


### PR DESCRIPTION
This PR overrides `RETIREMENT_SERVICE_GIT_REPOS` variable to pin `edx/tabular` version, because recent one contains `cryptography==3.4.7` dependency, which can't be installed in Juniper app server. 

[Ticket](https://tasks.opencraft.com/browse/BB-4082).

[Example of failed app server](https://manage.opencraft.com/instance/26150/edx-appserver/18408/).

[Test instance](https://manage.opencraft.com/instance/26290/).

[Mattermost thread](https://chat.opencraft.com/opencraft/pl/gycakygo1fyxfc5zmwx1jb67na).

Testing steps:
1. Open [test instance](https://manage.opencraft.com/instance/26290/)'s settings.
2. Ensure that it's a Juniper instance, that configuration version points to this branch, and that it's working.
