### PR TITLE
FAL-1764 Install both python-passlib and python3-passlib (koa port)

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -131,6 +131,7 @@ nginx_default_sites: []
 nginx_release_specific_debian_pkgs:
   xenial:
     - python-passlib
+    - python3-passlib
   bionic:
     - python-passlib
   focal:


### PR DESCRIPTION
Port https://github.com/edx/configuration/pull/6156 to our koa branch. See there for test instructions.