### PR TITLE
BB-4097 roles/oraclejdk: Add task for self hosted jdk

### DIFF
--- a/playbooks/roles/oraclejdk/tasks/main.yml
+++ b/playbooks/roles/oraclejdk/tasks/main.yml
@@ -21,6 +21,18 @@
     url: "{{ oraclejdk_url }}"
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
     dest: "/var/tmp/{{ oraclejdk_file }}"
+  when: USE_PRIVATE_ORACLEJDK is undefined or not USE_PRIVATE_ORACLEJDK
+
+- name: Download Oracle Java from private S3 bucket
+  aws_s3:
+    access_key: "{{ oraclejdk_s3.access_key }}"
+    secret_key: "{{ oraclejdk_s3.secret_key }}"
+    region: "{{ oraclejdk_s3.region }}"
+    bucket: "{{ oraclejdk_s3.bucket_name }}"
+    object: "{{ oraclejdk.filename | default(oraclejdk_file) }}"
+    dest: "/var/tmp/{{ oraclejdk_file }}"
+    mode: get
+  when: USE_PRIVATE_ORACLEJDK is defined and USE_PRIVATE_ORACLEJDK
 
 - name: Create jvm dir
   file:


### PR DESCRIPTION
Configuration Pull Request
---

Adds flag to allow downloading the oracle jdk from a private aws s3 bucket.

**JIRA Tickets**: [BB-4097](https://tasks.opencraft.com/browse/BB-4097)

**Testing Instructions**
1. Visit https://stage.manage.opencraft.com/instance/7770/edx-appserver/3280/
2. Check that the configuration uses branch `arjun/bb-4097-oraclejdk`
3. In appserver logs, check that task `Download Oracle Java from private S3 bucket` is run instead of `Download Oracle Java`
3. Verify that the Appserver is deployed successfully

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?

