### PR TITLE
[SE-4364] Update reindex_courses command to use --all option

### DIFF
--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -59,10 +59,3 @@
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   when: demo_checkout.changed
-
-- name: reindex all courses
-  shell: ". {{ demo_edxapp_env }} && yes | {{ demo_edxapp_venv_bin }}/python ./manage.py cms reindex_course --all --settings={{ demo_edxapp_settings }}"
-  args:
-    chdir: "{{ demo_edxapp_code_dir }}"
-  become_user: "{{ common_web_user }}"
-  when: EDXAPP_REINDEX_ALL_COURSES

--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -59,3 +59,10 @@
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   when: demo_checkout.changed
+
+- name: reindex all courses
+  shell: ". {{ demo_edxapp_env }} && yes | {{ demo_edxapp_venv_bin }}/python ./manage.py cms reindex_course --all --settings={{ demo_edxapp_settings }}"
+  args:
+    chdir: "{{ demo_edxapp_code_dir }}"
+  become_user: "{{ common_web_user }}"
+  when: EDXAPP_REINDEX_ALL_COURSES

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -483,16 +483,6 @@
     - manage
     - manage:db
 
-# - name: reindex all courses
-#   shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --setup --settings={{ edxapp_settings }}"
-#   args:
-#     chdir: "{{ edxapp_code_dir }}"
-#   become_user: "{{ common_web_user }}"
-#   when: EDXAPP_REINDEX_ALL_COURSES
-#   tags:
-#     - install
-#     - install:base
-
 - name: install cron job to run clearsessions
   cron:
     name: "clear expired Django sessions"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -483,15 +483,15 @@
     - manage
     - manage:db
 
-- name: reindex all courses
-  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --setup --settings={{ edxapp_settings }}"
-  args:
-    chdir: "{{ edxapp_code_dir }}"
-  become_user: "{{ common_web_user }}"
-  when: EDXAPP_REINDEX_ALL_COURSES
-  tags:
-    - install
-    - install:base
+# - name: reindex all courses
+#   shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --setup --settings={{ edxapp_settings }}"
+#   args:
+#     chdir: "{{ edxapp_code_dir }}"
+#   become_user: "{{ common_web_user }}"
+#   when: EDXAPP_REINDEX_ALL_COURSES
+#   tags:
+#     - install
+#     - install:base
 
 - name: install cron job to run clearsessions
   cron:

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -117,5 +117,12 @@
   tags:
     - deploy
 
+- name: reindex all courses
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && yes | {{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --all --settings={{ edxapp_settings }}"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ common_web_user }}"
+  when: EDXAPP_REINDEX_ALL_COURSES
+
 - set_fact:
     forum_installed: true


### PR DESCRIPTION
After upgrading to Koa, it was noticed that the courseware search stops working (after redeployment). Running `reindex_courses` command fixes the issue. We already have a config variable, `EDXAPP_REINDEX_ALL_COURSES` that when set will run `reindex_courses` command during deployment. However, it does not use the `--all` option as the name suggests, but rather uses `--setup` option. The setup option should only be used in a devstack installation and does not reindex courses in a production setup. This PR updates the ansible task to use `--all` option instead of `--setup` option.

**Testing Instruction:**

1. Use this PR branch to deploy new OCIM instance.
2. Ensure `EDXAPP_REINDEX_ALL_COURSES` is set to true in the config variables.
3. Also set `ENABLE_COURSEWARE_SEARCH` and `ENABLE_DASHBOARD_SEARCH` to true, to enable courseware search.
4. Wait for instance deployment to complete.
5. Verify that the courseware search (in the right hand side of the dashboard page) works by returning some known search results.


**Reviewers:**
- [ ] @gabor-boros 
