### PR TITLE
Add ECOMMERCE_EXTRA_REQUIREMENTS configuration variable

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -22,6 +22,17 @@ ECOMMERCE_REPOS:
     DESTINATION: "{{ ecommerce_code_dir }}"
     SSH_KEY: "{{ ECOMMERCE_GIT_IDENTITY }}"
 
+# List of additional python packages that should be installed into the
+# ecommerce virtual environment.
+# `name` (required), `version` (optional), and `extra_args` (optional)
+# are supported and correspond to the options of ansible's pip module.
+# Example:
+# ECOMMERCE_EXTRA_REQUIREMENTS:
+#   - name: mypackage
+#     version: 1.0.1
+#   - name: git+https://git.myproject.org/MyProject#egg=MyProject
+ECOMMERCE_EXTRA_REQUIREMENTS: []
+
 # depends upon Newrelic being enabled via COMMON_ENABLE_NEWRELIC
 # and a key being provided via NEWRELIC_LICENSE_KEY
 ECOMMERCE_NEWRELIC_APPNAME: "{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-{{ ecommerce_service_name }}"

--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -20,3 +20,17 @@
   tags:
     - install
     - install:configuration
+
+# Install any custom extra requirements if defined in ECOMMERCE_EXTRA_REQUIREMENTS.
+- name: install python extra requirements
+  pip:
+    name: "{{ item.name }}"
+    version: "{{ item.version|default(omit) }}"
+    extra_args: "--exists-action w {{ item.extra_args|default('') }}"
+    virtualenv: "{{ ecommerce_venv_dir }}"
+    state: present
+  with_items: "{{ ECOMMERCE_EXTRA_REQUIREMENTS }}"
+  become_user: "{{ ecommerce_user }}"
+  tags:
+    - install
+    - install:app-requirements


### PR DESCRIPTION
Configuration Pull Request
---

Adds configuration to install extra python requirements for ecommerce.
This adds a new configuration variable `ECOMMERCE_EXTRA_REQUIREMENTS`, and an ansible task which installs these python requirements via pip in the ecommerce virtualenv.

**JIRA Tickets**: [BB-3315](https://tasks.opencraft.com/browse/BB-3315)

**Testing Instructions**
1. Deploy an Application Server with ecommerce configured and python requirements in `ECOMMERCE_EXTRA_REQUIREMENTS`
2. Verify that extra python requirements are installed in the ecommerce virtualenv

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
