### PR TITLE
[FAL-1865] Set openedx_native to use new openjdk role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+ - 2021-05-05
+    - Role: openjdk
+        - Added a new role to install OpenJDK.
+        - Configure the version used with `OPENJDK_MAJOR_VERSION` 
+          (defaults to version 8).
+    - Playbook: openedx_native
+        - Modify to use the new `openjdk` role (instead of the default
+          `oraclejdk`) when the `USE_OPENJDK` flag is set.
+    - Role: elasticsearch
+        - Modify to use the new `openjdk` role (instead of the default
+          `oraclejdk`) when the `USE_OPENJDK` flag is set.
+        
  - 2021-07-03
     - Role: ecommerce
       - Added new configuration variable ECOMMERCE_EXTRA_CONFIG_OVERRIDES, which will allow override any ecommerce settings.

--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -39,6 +39,7 @@
     ECOMMERCE_ENABLE_COMPREHENSIVE_THEMING: false
     EDXAPP_ENABLE_MEMCACHE: true
     EDXAPP_ENABLE_ELASTIC_SEARCH: true
+    USE_OPENJDK: false
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB
@@ -86,7 +87,10 @@
     - role: demo
       when: DEMO_ROLE_ENABLED
     - oauth_client_setup
-    - oraclejdk
+    - role: openjdk
+      when: USE_OPENJDK|default(false)|bool
+    - role: oraclejdk
+      when: not USE_OPENJDK|default(false)|bool
     - role: elasticsearch
       when: EDXAPP_ENABLE_ELASTIC_SEARCH
     - forum

--- a/playbooks/roles/elasticsearch/meta/main.yml
+++ b/playbooks/roles/elasticsearch/meta/main.yml
@@ -1,4 +1,9 @@
 ---
 dependencies:
-  - common
-  - oraclejdk
+  - role: common
+
+  - role: openjdk
+    when: USE_OPENJDK|default(false)|bool
+
+  - role: oraclejdk
+    when: not USE_OPENJDK|default(false)|bool

--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -5,7 +5,7 @@
 # Dependencies:
 #
 #   * common
-#   * oraclejdk
+#   * openjdk
 #
 # Example play:
 #
@@ -25,7 +25,7 @@
 # -  hosts: tag_role_elasticsearch:&tag_environment_stage
 #    roles:
 #    - common
-#    - oraclejdk
+#    - openjdk
 #    - elasticsearch
 #
 

--- a/playbooks/roles/openjdk/defaults/main.yml
+++ b/playbooks/roles/openjdk/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Set this to 8 for Juniper and earlier releases
+OPENJDK_MAJOR_VERSION: 8

--- a/playbooks/roles/openjdk/tasks/main.yml
+++ b/playbooks/roles/openjdk/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# oraclejdk
+#
+# Example play:
+#
+#   roles:
+#   - oraclejdk
+
+- name: OpenJDK has been installed with its dependencies
+  apt:
+    name: "openjdk-{{OPENJDK_MAJOR_VERSION}}-jdk"
+    update_cache: true


### PR DESCRIPTION
Create a new role `openjdk` to install the free version of `java` and configure `openedzx_native.yml` playbook and the `elasticsearch` role to use that new role in place of `oraclejdk`.

**JIRA tickets**: https://tasks.opencraft.com/browse/FAL-1865

**Testing instructions**:

1. Check the OCIM sandbox at https://manage.opencraft.com/instance/26850/edx-appserver/18898/ and note that it has been configured to load this branch and sets  `USE_OPENJDK: true`
2. Shell into the corresponding appserver:
```
ssh 213.32.73.137
```
3. Check that elasticsearch is running and that it is using the system `/bin/java`:
```console
$ ps -ef | grep -i elasticsearch
elastic+     356       1  0 May04 ?        00:00:28 /bin/java -Xms512m -Xmx512m -Djava.awt.headless=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -XX:+DisableExplicitGC -Dfile.encoding=UTF-8 -Delasticsearch -Des.foreground=yes -Des.path.home=/usr/share/elasticsearch -cp :/usr/share/elasticsearch/lib/elasticsearch-1.5.2.jar:/usr/share/elasticsearch/lib/*:/usr/share/elasticsearch/lib/sigar/* -Des.default.config= -Des.default.path.home=/usr/share/elasticsearch -Des.default.path.logs=/edx/var/log/elasticsearch -Des.default.path.data=/edx/var -Des.default.path.work= -Des.default.path.conf=/edx/etc/elasticsearch org.elasticsearch.bootstrap.Elasticsearch
tartans+    3922    3722  0 01:36 pts/0    00:00:00 grep --color=auto java
```
4. Check that the system `/bin/java` is OpenJDK:
```console
$ /bin/java -version
openjdk version "1.8.0_292"
OpenJDK Runtime Environment (build 1.8.0_292-8u292-b10-0ubuntu1~20.04-b10)
OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
$ 
```

**Author notes and concerns**:

1. The major version installed can be configured with `OPENJDK_MAJOR_VERSION`.  I choose to default to version 8 for maximum compatibility, bit 11 should work for Koa.  I don't think this has to be set in secure vars, but don't have access to confirm.

**Reviewers**:

- [ ] @eLRuLL 

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
