### PR TITLE
fix: pin setuptools version [BB-4212]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,5 @@ simplejson==3.16.0        # via datadog
 six==1.11.0               # via bcrypt, cryptography, pathlib2, pynacl, python-dateutil
 urllib3==1.22             # via requests
 wsgiref==0.1.2
+
+setuptools==44.1.1  # 45.0.0 is installed by default, but it requires Python>=3.5


### PR DESCRIPTION
45.0.0 is installed by default, but it requires Python>=3.5.