### PR TITLE
[BB-3801] feat: allow writing extra requirements to a requirements file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2021-07-19
+     - Role: edx_django_service
+        - Allows writing extra requirements to an 'extra.txt' requirements file in the service's requirements directory.
+     - Role: ecommerce
+        - Adds an optional flag to write the extra requirements to an 'extra.txt' file since many of the app's setup commands
+          use tox and that creates its own environments separate from the default ecommerce virtualenv environment where the
+          `ECOMMERCE_EXTRA_REQUIREMENTS` requirements are installed.
+
  - 2021-06-17
     - Role credentials
        - Installs extra python packages specified in `CREDENTIALS_EXTRA_REQUIREMENTS` (defaults to `[]`).

--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -32,6 +32,7 @@ ECOMMERCE_REPOS:
 #     version: 1.0.1
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
 ECOMMERCE_EXTRA_REQUIREMENTS: []
+ECOMMERCE_ADD_EXTRA_REQUIREMENTS_TO_REQUIREMENTS_FILE: false
 
 # depends upon Newrelic being enabled via COMMON_ENABLE_NEWRELIC
 # and a key being provided via NEWRELIC_LICENSE_KEY

--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -22,6 +22,7 @@ dependencies:
     edx_django_service_debian_pkgs_extra: '{{ ecommerce_debian_pkgs + ecommerce_release_specific_debian_pkgs[ansible_distribution_release] }}'
     edx_django_service_django_settings_module: '{{ ECOMMERCE_DJANGO_SETTINGS_MODULE }}'
     edx_django_service_extra_requirements: '{{ ECOMMERCE_EXTRA_REQUIREMENTS }}'
+    edx_django_service_add_extra_requirements_to_requirements_file: '{{ ECOMMERCE_ADD_EXTRA_REQUIREMENTS_TO_REQUIREMENTS_FILE }}'
     edx_django_service_repos: '{{ ECOMMERCE_REPOS }}'
     edx_django_service_environment_extra: '{{ ecommerce_environment }}'
     edx_django_service_gunicorn_extra: '{{ ECOMMERCE_GUNICORN_EXTRA }}'

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -193,6 +193,17 @@
     - install
     - install:app-requirements
 
+- name: add extra requirements to extra.txt
+  lineinfile:
+    path: "{{ edx_django_service_code_dir }}/requirements/extra.txt"
+    line: "{{ item.name }}"
+  become_user: "{{ edx_django_service_user }}"
+  with_items: "{{ edx_django_service_extra_requirements }}"
+  when: edx_django_service_add_extra_requirements_to_requirements_file is defined and edx_django_service_add_extra_requirements_to_requirements_file
+  tags:
+    - install
+    - install:app-requirements
+
 - name: Check for existing make_migrate container
   command: "docker ps -aq --filter name='{{ edx_django_service_name }}.make_migrate'"
   register: edx_django_service_make_migrate_container


### PR DESCRIPTION
This is useful for apps like ecommerce, which use tox to run the
migrations and the dependencies for the tox environments are expected
to be defined in a requirements file.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [x] Add an entry to the CHANGELOG.
  - [x] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
