### PR TITLE
[FAL-2409] Use the tubular pygithub fix in our common branch

### DIFF
--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -40,6 +40,14 @@
     EDXAPP_ENABLE_MEMCACHE: true
     EDXAPP_ENABLE_ELASTIC_SEARCH: true
     ENABLE_UPTIME_REPORT: true
+    RETIREMENT_SERVICE_GIT_REPOS:
+      - PROTOCOL: "{{ COMMON_GIT_PROTOCOL }}"
+        DOMAIN: "{{ COMMON_GIT_MIRROR }}"
+        PATH: "open-craft"
+        REPO: "tubular.git"
+        VERSION: "opencraft-release/koa.3"
+        DESTINATION: "{{ retirement_service_app_dir }}"
+        SSH_KEY: "{{ RETIREMENT_SERVICE_GIT_IDENTITY }}"
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB


### PR DESCRIPTION
This PR pins the tubular repository version to the `opencraft-release/koa.3` branch of our maintained fork since it has the fix to the PyGitHub issue mentioned in FAL-2409.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
