### PR TITLE
[BB-3801] fix: ignore extra.txt local changes

### DIFF
--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -204,6 +204,16 @@
     - install
     - install:app-requirements
 
+- name: git ignore local changes to extra.txt
+  command: "git update-index --skip-worktree {{ edx_django_service_code_dir }}/requirements/extra.txt"
+  args:
+    chdir: "{{ edx_django_service_code_dir }}"
+  become_user: "{{ edx_django_service_user }}"
+  when: edx_django_service_add_extra_requirements_to_requirements_file is defined and edx_django_service_add_extra_requirements_to_requirements_file
+  tags:
+    - install
+    - install:app-requirements
+
 - name: Check for existing make_migrate container
   command: "docker ps -aq --filter name='{{ edx_django_service_name }}.make_migrate'"
   register: edx_django_service_make_migrate_container


### PR DESCRIPTION
This PR is a follow-up to https://github.com/open-craft/configuration/pull/172 with a fix that allows the git local working directory to be clean so that the Ansible tasks required by this don't fail. This error wasn't happening in all the environments, but was repeatedly happening in a non-production environment of one of our clients.

**Testing instructions**:
* Check the EC2 instance deployed with this fix and verify that though the local changes to `extra.txt` are there, `git` doesn't track them at all.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
