### PR TITLE
[SE-5139] Fix uptime report generation script for Esme

### DIFF
--- a/playbooks/roles/uptime_report/templates/uptime_report_script.j2
+++ b/playbooks/roles/uptime_report/templates/uptime_report_script.j2
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import boto3
 import json


### PR DESCRIPTION
This PR updates the uptime generation script to use python3.

**JIRA tickets:** [SE-5139](https://tasks.opencraft.com/browse/SE-5139)

**Testing Instructions:**
1. Run `/edx/var/upload_uptime_report.py` to make sure the script is working.
2. Run `crontab -l` as root to make sure the script is run daily
3. Check the S3 bucket to verify that uptime reports are being uploaded

Note: I already manually updated the script on the Said-Oxford instance and tested it

**Reviewers:**

- [ ] @gabor-boros 