### PR TITLE
[SE-5266] Add cron job for updating completion aggregator

### DIFF
--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -41,6 +41,7 @@
     EDXAPP_ENABLE_ELASTIC_SEARCH: true
     EDXAPP_ENABLE_COURSE_GRADES_FETCH: true
     ENABLE_UPTIME_REPORT: true
+    ENABLE_COMPLETION_AGGREGATOR_UPDATE_CRON: true
     RETIREMENT_SERVICE_GIT_REPOS:
       - PROTOCOL: "{{ COMMON_GIT_PROTOCOL }}"
         DOMAIN: "{{ COMMON_GIT_MIRROR }}"
@@ -119,3 +120,5 @@
     - role: mfe_deployer
     - role: uptime_report
       when: ENABLE_UPTIME_REPORT
+    - role: update-completion-aggregator
+      when: ENABLE_COMPLETION_AGGREGATOR_UPDATE_CRON

--- a/playbooks/roles/update-completion-aggregator/defaults/main.yml
+++ b/playbooks/roles/update-completion-aggregator/defaults/main.yml
@@ -1,0 +1,19 @@
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#
+# Deploy completion aggregator update cron job
+#
+# See documentation in README.rst
+
+#
+# This file contains the variables you'll need to pass to the role, and some
+# example values.
+
+update_completion_aggregator_script: "/edx/var/update_completion_aggregator.sh"
+COMPLETION_AGGREGATOR_ENABLE_CRON_JOB: false
+update_completion_cron_job_hours: "*"
+update_completion_cron_job_minutes: 0

--- a/playbooks/roles/update-completion-aggregator/tasks/main.yml
+++ b/playbooks/roles/update-completion-aggregator/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#
+#
+# Tasks for role update-completion-aggregator
+#
+# Overview:
+# This role will be used to set up cron job for updating completion aggregator
+# Example play:
+#
+#
+
+- name: Create bash script to tasks to update completion aggregator
+  template:
+    dest: "{{ update_completion_aggregator_script }}"
+    src: "update_completion_aggregator_script.j2"
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Install cron job for automatically running the update completion aggregator script
+  cron:
+    name: "Run update completion aggregator script"
+    job: "{{ update_completion_aggregator_script }}"
+    hour: "{{ update_completion_cron_job_hours }}"
+    minute: "{{ update_completion_cron_job_minutes }}"
+    day: "*"
+  when: COMPLETION_AGGREGATOR_ENABLE_CRON_JOB

--- a/playbooks/roles/update-completion-aggregator/templates/update_completion_aggregator_script.j2
+++ b/playbooks/roles/update-completion-aggregator/templates/update_completion_aggregator_script.j2
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Ensure only one instance of the script is running
+LOCKFILE=/edx/var/completion-aggregator.lock
+if [ -e ${LOCKFILE} ] && kill -0 `cat ${LOCKFILE}`; then
+    echo "Completion aggregator update already running!"
+    exit
+fi
+# make sure the lockfile is removed when we exit and then claim it
+trap "rm -f ${LOCKFILE}; exit" INT TERM EXIT
+echo $$ > ${LOCKFILE}
+
+# Set environment
+. /edx/app/edxapp/edxapp_env
+
+# Source virtualenv
+source /edx/app/edxapp/venvs/edxapp/bin/activate
+
+# Run aggregator service to update any stale aggregate completion data
+/edx/app/edxapp/edx-platform/manage.py lms run_aggregator_service \
+        --settings=production
+
+# Run aggregator cleanup to delete old database entries
+/edx/app/edxapp/edx-platform/manage.py lms run_aggregator_cleanup \
+        --settings=production
+
+# Clear the lockfile
+rm -f $LOCKFILE


### PR DESCRIPTION
This PR adds a cron job for updating completion aggregator. It introduces a new flag `COMPLETION_AGGREGATOR_ENABLE_CRON_JOB` which would be required to be set to `true`, if the cron job needs to be scheduled i.e. the completion aggregator is set in async mode.

**Testing Instructions:**

1. Set the instance config to use this branch and deploy a new appserver. Make sure to set the cron job flag i.e. `COMPLETION_AGGREGATOR_ENABLE_CRON_JOB` to `true`.
2. Once the appserver is running, ensure completion aggregator is set to async mode i.e. set `COMPLETION_AGGREGATOR_ASYNC_AGGREGATION` to `true` in the `lms.yml` file.
3. Verify the progress bar is working as expected and the cron job runs correctly.

**Reviewers:**
- [ ] @gabor-boros 
