### PR TITLE
feat: add nginx server names hash override [BB-5512]

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -21,6 +21,10 @@ NGINX_OVERRIDE_DEFAULT_MAP_HASH_SIZE: False
 NGINX_MAP_HASH_MAX_SIZE: 2048
 NGINX_MAP_HASH_BUCKET_SIZE: 64
 
+# Override these vars to alter the memory allocated to server_names_hash
+NGINX_OVERRIDE_DEFAULT_SERVER_NAMES_HASH_SIZE: False
+NGINX_SERVER_NAMES_HASH_BUCKET_SIZE: 64
+
 # Override these vars for adding user to nginx.htpasswd
 NGINX_USERS:
   - name: "{{ COMMON_HTPASSWD_USER }}"

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -27,7 +27,9 @@ http {
         large_client_header_buffers 8 16k;
         server_tokens off;
 
-        # server_names_hash_bucket_size 64;
+        {% if NGINX_OVERRIDE_DEFAULT_SERVER_NAMES_HASH_SIZE %}
+        server_names_hash_bucket_size {{ NGINX_SERVER_NAMES_HASH_BUCKET_SIZE }};
+        {% endif %}
         # server_name_in_redirect off;
 
         include /etc/nginx/mime.types;


### PR DESCRIPTION
## Description

(cherry picked from commit 59cbc50)

This PR adds support for optional configuration of nginx server_names_hash_bucket_size in case length of the hostname exceeds the default hash bucket size.

## Supporting information

[BB-5512](https://tasks.opencraft.com/browse/BB-5512)
[OCIM stage instance](https://stage.manage.opencraft.com/instance/9110/edx-appserver/3678/)

## Testing instructions

1. Go to [OCIM stage instance](https://stage.manage.opencraft.com/instance/9110/edx-appserver/3678/)
2. Verify the new configurations variables are set in configuration_extra_settings
3. Verify [LMS](https://testverylongnginxservername.stage.opencraft.hosting/) is up
4. SSH into the appserver and check `/etc/nginx/nginx.conf` file to verify `server_names_hash_bucket_size` is set to `128`
5. Remove the new configuration variables
6. Launch a new app server
7. New app server deployment should now fail
8. SSH into the failed app server
9. Verify `server_names_hash_bucket_size` not set in `/etc/nginx/nginx.conf` file 
10. `sudo service nginx status` to verify nginx error



## Other information
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
