### PR TITLE
feat: add SIMPLETHEME_I18N_DJANGO variable

### DIFF
--- a/playbooks/roles/simple_theme/defaults/main.yml
+++ b/playbooks/roles/simple_theme/defaults/main.yml
@@ -106,3 +106,37 @@ SIMPLETHEME_STATIC_FILES_URLS: []
 #     border-top: 3px solid $main-color;
 #   }
 SIMPLETHEME_EXTRA_SASS: ""
+
+
+# Use this variable to configure django translations.
+# Note that edx-platform does not pick up translations from themes by default.
+# You will have to manually configure either `COMPREHENSIVE_THEME_LOCALE_PATHS` or
+# `PREPEND_LOCALE_PATHS` to include the path to the theme's i18n/locale folder for
+# these translations to get picked up.
+#
+# The SIMPLETHEME_I18n_DJANGO variable should contain a list of dictionaries with these keys:
+# - `lang`: the language code
+# - `domain`: the i18n domain (typically one of "django" or "djangojs")
+# - `headers`: (optional) Additional PO file headers.
+# - `messages`: Translation messages. It should be a raw string of PO formatted messages.
+#
+# Samle:
+# SIMPLETHEME_I18N_DJANGO:
+#   - lang: en
+#     domain: django
+#     headers: |
+#       "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#     messages: |
+#       msgid "my id"
+#       msgstr "my translation"
+#
+#       msgid "one"
+#       msgid_plural "many"
+#       msgstr[0] "just one"
+#       msgstr[1] "a lot"
+#   - lang: en
+#     domain: djangojs
+#     messages: |
+#       msgid "my id"
+#       msgstr "my JS translation"
+SIMPLETHEME_I18N_DJANGO: []

--- a/playbooks/roles/simple_theme/tasks/deploy.yml
+++ b/playbooks/roles/simple_theme/tasks/deploy.yml
@@ -137,3 +137,45 @@
       owner: "{{ edxapp_user }}"
       group: "{{ common_web_group }}"
     with_items: "{{ SIMPLETHEME_STATIC_FILES_URLS }}"
+
+# Handle translations.
+- block:
+  - name: Install needed packages
+    apt:
+      name: gettext
+      state: present
+      update_cache: true
+      cache_valid_time: 3600
+  - name: Create directories for django translations
+    file:
+      path: "{{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES"
+      state: directory
+      owner: "{{ edxapp_user }}"
+      group: "{{ common_web_group }}"
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  - name: Make sure .po files exist
+    file:
+      path: "{{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po"
+      state: touch
+      owner: "{{ edxapp_user }}"
+      group: "{{ common_web_group }}"
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  - name: Create temporary .po files with custom translations
+    template:
+      src: "i18n/domain.po.j2"
+      dest: "{{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po_"
+      owner: "{{ edxapp_user }}"
+      group: "{{ common_web_group }}"
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  - name: Merge temporary .po files into default translations
+    shell: >
+      msgcat --use-first {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po_
+      {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po >
+      {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  - name: Compile .po files into .mo
+    shell: >
+      msgfmt {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po
+      -o {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.mo
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  when: SIMPLETHEME_I18N_DJANGO | length > 0

--- a/playbooks/roles/simple_theme/templates/i18n/domain.po.j2
+++ b/playbooks/roles/simple_theme/templates/i18n/domain.po.j2
@@ -1,0 +1,12 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: {{ item.lang }}\n"
+{% if 'headers' in item -%}
+{{ item.headers }}
+{%- endif %}
+
+{% if 'messages' in item -%}
+{{ item.messages }}
+{%- endif %}


### PR DESCRIPTION
This makes it possible to add or override django translations via the simple-theme role.

This cherry-picks changes from https://github.com/openedx/configuration/pull/6679 into the `opencraft-release/lilac.2` branch.
