### PR TITLE
feat: optionally collect JS translations on deploy

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -618,6 +618,9 @@ EDXAPP_DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL: True
 # Whether to run reindex_course on deploy
 EDXAPP_REINDEX_ALL_COURSES: false
 
+# Whether to run compilejsi18n on deploy
+EDXAPP_COMPILE_JSI18N: false
+
 # XML Course related flags
 EDXAPP_XML_FROM_GIT: false
 EDXAPP_XML_S3_BUCKET: !!null

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -383,6 +383,15 @@
   when:
     - celery_worker is not defined
 
+- name: compile JS translations
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} compilejsi18n"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ edxapp_user }}"
+  when: EDXAPP_COMPILE_JSI18N and celery_worker is not defined
+  tags:
+    - assets
+
 # creates the supervisor jobs for the
 # service variants configured, runs
 # gather_assets and db migrations


### PR DESCRIPTION
If the `EDXAPP_COMPILE_JSI18N` is enabled, this will invoke the `compilejsi18n` management command when deploying edxapp.

This is useful when you use custom JS translations for example via a theme.

This cherry-picks changes from https://github.com/openedx/configuration/pull/6708