### PR TITLE
fix: Use repo owner user for git operations

### DIFF
--- a/playbooks/roles/git_clone/tasks/main.yml
+++ b/playbooks/roles/git_clone/tasks/main.yml
@@ -57,6 +57,7 @@
 - name: Check that working tree is clean
   shell: test ! -e "{{ item }}" || git -C "{{ item }}" status --porcelain --untracked-files=no
   register: dirty_files
+  become_user: "{{ repo_owner }}"
   # Using the map here means that the items will only be the DESTINATION strings,
   # rather than the full GIT_REPOS structures, which have data we don't want to log,
   # so we don't have to use no_log on this task.
@@ -113,7 +114,7 @@
 
 - name: Run git clean after checking out code
   shell: cd {{ item.DESTINATION }} && git clean -xdf
-  become: true
+  become_user: "{{ repo_owner }}"
   with_items: "{{ GIT_REPOS }}"
   no_log: "{{ GIT_CLONE_NO_LOGGING }}"
   tags:


### PR DESCRIPTION
Cherry pick of: https://github.com/openedx/configuration/pull/6717

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Are you adding/updating any variables that need to be added/updated to a specific `configuration-secure` repo?
