### PR TITLE
fix: revert Celery command change for services using Celery<5

### DIFF
--- a/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
+++ b/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
@@ -17,4 +17,4 @@ export NEW_RELIC_LICENSE_KEY='{{ NEWRELIC_LICENSE_KEY }}'
 
 source {{ ecommerce_worker_home }}/{{ ecommerce_worker_service_name }}_env
 # We exec so that celery is the child of supervisor and can be managed properly
-exec {{ executable }} --app ecommerce_worker.celery_app:app worker -A ecommerce_worker --concurrency={{ ECOMMERCE_WORKER_CONCURRENCY }} --loglevel=info --hostname=ecomworker.%%h --queue=ecommerce.fulfillment,ecommerce.email_marketing
+exec {{ executable }} -A ecommerce_worker worker --app ecommerce_worker.celery_app:app --concurrency={{ ECOMMERCE_WORKER_CONCURRENCY }} --loglevel=info --hostname=ecomworker.%%h --queue=ecommerce.fulfillment,ecommerce.email_marketing

--- a/playbooks/roles/edx_django_service/templates/edx/app/supervisor/conf.d.available/app-workers.conf.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/supervisor/conf.d.available/app-workers.conf.j2
@@ -10,7 +10,7 @@ directory={{ edx_django_service_code_dir }}
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 
-command={{ edx_django_service_home }}/{{ edx_django_service_name }}-workers.sh --app {{ edx_django_service_name }}.celery:app worker -A {{ edx_django_service_name }} --loglevel=info --queue={{ w.queue }} --hostname={{ edx_django_service_name }}.{{ w.queue }}.%%h --concurrency=1 {{ '--max-tasks-per-child ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }} {{ '--without-heartbeat' if not edx_django_service_celery_heartbeat_enabled|bool else '' }}
+command={{ edx_django_service_home }}/{{ edx_django_service_name }}-workers.sh worker -A {{ edx_django_service_name }} --app {{ edx_django_service_name }}.celery:app --loglevel=info --queue={{ w.queue }} --hostname={{ edx_django_service_name }}.{{ w.queue }}.%%h --concurrency=1 {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }} {{ '--without-heartbeat' if not edx_django_service_celery_heartbeat_enabled|bool else '' }}
 killasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(edx_django_service_default_stopwaitsecs) }}
 
@@ -34,7 +34,7 @@ stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 {% set worker_app_name = 'course_discovery' %}
 {% endif %}
 
-command={{ edx_django_service_home }}/{{ edx_django_service_name }}-workers.sh --app {{ worker_app_name }}.celery:app worker -A {{ edx_django_service_name }} --loglevel=info --queue={{ w.queue }} --hostname={{ edx_django_service_name }}.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--max-tasks-per-child ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }} {{ '--without-heartbeat' if not edx_django_service_celery_heartbeat_enabled|bool else '' }}
+command={{ edx_django_service_home }}/{{ edx_django_service_name }}-workers.sh worker -A {{ edx_django_service_name }} --app {{ worker_app_name }}.celery:app --loglevel=info --queue={{ w.queue }} --hostname={{ edx_django_service_name }}.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }} {{ '--without-heartbeat' if not edx_django_service_celery_heartbeat_enabled|bool else '' }}
 killasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(edx_django_service_default_stopwaitsecs) }}
 


### PR DESCRIPTION
Fixes #186. Celery was upgraded only for the `edx-platform`. Other repositories are still using Celery<5.

This directly affects [ecommerce-worker](https://github.com/openedx/ecommerce-worker) and breaks the deployment process when [SANDBOX_ENABLE_ECOMMERCE: true](https://github.com/openedx/configuration/blob/bd1f52aff62869f2d1214827fca70665e5e245d3/playbooks/openedx_native.yml#L50) is defined.

The `/edx/var/log/supervisor/ecomworker-stderr.log` file contains:
```
Error: 
Unable to load celery application.
Module 'ecommerce_worker' has no attribute 'celery'
```

<br/><br/>

The following services could also be affected:
- [registrar](https://github.com/openedx/configuration/blob/dbd9a462b53bbd66a76482b05e301b3f5bd9f618/playbooks/roles/registrar/meta/main.yml#L53)
- [discovery](https://github.com/openedx/configuration/blob/50978d732a3854d75f380e31811afb54e2df80f6/playbooks/roles/discovery/meta/main.yml#L59)
- [enterprise_catalog](https://github.com/openedx/configuration/blob/983cb796be69278d8b0e71690a614f3e0ca19325/playbooks/roles/enterprise_catalog/meta/main.yml#L51)
- [license_manager](https://github.com/openedx/configuration/blob/d83f249916fd3a9aa6c62f4c244377eb07626200/playbooks/roles/license_manager/meta/main.yml#L53)

However, I've noticed something odd in the `edx_django_service` playbook. While supervisor **worker** configs [are created](https://github.com/openedx/configuration/blob/c7bc4c25b844d9709ef2dc18a151d6e91f0d2c2a/playbooks/roles/edx_django_service/tasks/main.yml#L303-L313) for these services, no task would [enable them](https://github.com/openedx/configuration/blob/a4bccdb7994f2485a4629ae1f4fb97d1d73e934b/playbooks/roles/ecomworker/tasks/main.yml#L57-L66). There is only a task which [creates](https://github.com/openedx/configuration/blob/c7bc4c25b844d9709ef2dc18a151d6e91f0d2c2a/playbooks/roles/edx_django_service/tasks/main.yml#L292-L301) and [enables](https://github.com/openedx/configuration/blob/c7bc4c25b844d9709ef2dc18a151d6e91f0d2c2a/playbooks/roles/edx_django_service/tasks/main.yml#L339-L348) the config for the service's **main process**.

FYI: @gabor-boros 