### PR TITLE
[BACKPORT][BB-6154] Fix "send-logs-to-object-store" to use the correct python executable

### DIFF
--- a/playbooks/roles/aws/templates/send-logs-to-s3.j2
+++ b/playbooks/roles/aws/templates/send-logs-to-s3.j2
@@ -97,7 +97,7 @@ onerror() {
     message_file=/var/tmp/message-$$.json
     message_string="Error syncing $s3_path: inst_id=$instance_id ip=$ip region={{ aws_region }}"
     if [[ -r "{{ aws_s3_logfile }}" ]]; then
-      python -c "import json; d={'Subject':{'Data':'$message_string'},'Body':{'Text':{'Data':open('"{{ aws_s3_logfile }}"').read()}}};print json.dumps(d)" > $message_file
+      python3 -c "import json; d={'Subject':{'Data':'$message_string'},'Body':{'Text':{'Data':open('"{{ aws_s3_logfile }}"').read()}}};print(json.dumps(d))" > $message_file
     else
       cat << EOF > $message_file
       {"Subject": { "Data": "$message_string" }, "Body": { "Text": { "Data": "!! ERROR !! no logfile" } } }


### PR DESCRIPTION
## Description

Backport of https://github.com/openedx/configuration/pull/6755.