### PR TITLE
[BB-6228] Allow deactivating waffle flags

### DIFF
--- a/playbooks/roles/mfe_flags_setup/defaults/main.yml
+++ b/playbooks/roles/mfe_flags_setup/defaults/main.yml
@@ -3,3 +3,5 @@
 MFE_FLAGS_SETUP_FLAGS_LIST:
   - account.redirect_to_microfrontend
   - order_history.redirect_to_microfrontend
+
+MFE_FLAGS_SETUP_DEACTIVATE_LIST: []

--- a/playbooks/roles/mfe_flags_setup/tasks/main.yml
+++ b/playbooks/roles/mfe_flags_setup/tasks/main.yml
@@ -35,3 +35,11 @@
   environment: "{{ edxapp_environment }}"
   when: item not in edxapp_waffle_flags_list.stdout
   loop: "{{ MFE_FLAGS_SETUP_FLAGS_LIST }}"
+
+- name: Create deactivate MFE waffle flag if it does not exist
+  shell: >
+    {{ edxapp_venv_bin }}/python {{ COMMON_BIN_DIR }}/manage.edxapp lms waffle_flag {{ item }} --deactivate --create --settings={{ COMMON_EDXAPP_SETTINGS }}
+  become_user: "{{ edxapp_user }}"
+  environment: "{{ edxapp_environment }}"
+  when: item not in edxapp_waffle_flags_list.stdout
+  loop: "{{ MFE_FLAGS_SETUP_DEACTIVATE_LIST }}"


### PR DESCRIPTION
## Description

This PR allows for adding deactivating Waffle flags specifically to disable the accounts MFE

## Testing instructions

This PR is being used to deploy https://maple-test.stage.opencraft.hosting/
Ensure the "account.redirect_to_microfrontend" [waffle flag](https://maple-test.stage.opencraft.hosting/admin/waffle/flag/) is properly created and deactivated for Everyone.

## Deadline

End of sprint