### PR TITLE
[BB-6458] Fix tasks that create django users for IDAs

### DIFF
--- a/playbooks/manage_edxapp_users_and_groups.yml
+++ b/playbooks/manage_edxapp_users_and_groups.yml
@@ -197,7 +197,7 @@
         {% if item.get('permissions', []) | length %}--permissions {{ item.permissions | default([]) | map('quote') | join(' ') }}{% endif %}
         {% if item.get('remove') %}--remove{% endif %}
       with_items: "{{ django_groups }}"
-      when: (not group_environment) or group_environment in item.environments
+      when: (service | length > 0) and (not group_environment) or group_environment in item.environments
       become: true
       become_user: "{{ common_web_user }}"
 
@@ -214,7 +214,7 @@
         {% if item.get('unusable_password') %}--unusable-password{% endif %}
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: "{{ django_users }}"
-      when: not item.get('unusable_password')
+      when: (service | length > 0) and not item.get('unusable_password')
       register: manage_users_result
       failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors | bool)
       retries: 3
@@ -235,7 +235,7 @@
         {% if item.get('unusable_password') %}--unusable-password{% endif %}
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: "{{ django_users }}"
-      when: item.get('unusable_password')
+      when: (service | length > 0) and item.get('unusable_password')
       register: manage_users_result
       failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors | bool)
       retries: 3

--- a/playbooks/manage_edxapp_users_and_groups.yml
+++ b/playbooks/manage_edxapp_users_and_groups.yml
@@ -129,7 +129,7 @@
         {% if item.get('permissions', []) | length %}--permissions {{ item.permissions | default([]) | map('quote') | join(' ') }}{% endif %}
         {% if item.get('remove') %}--remove{% endif %}
       with_items: "{{ django_groups }}"
-      when: (not group_environment) or group_environment in item.environments
+      when: (not service) and (not group_environment) or group_environment in item.environments
       become: true
       become_user: "{{ common_web_user }}"
 
@@ -142,7 +142,7 @@
         {% if item.get('permissions', []) | length %}--permissions {{ item.permissions | default([]) | map('quote') | join(' ') }}{% endif %}
         {% if item.get('remove') %}--remove{% endif %}
       with_items: "{{ django_groups }}"
-      when: (not group_environment) or group_environment in item.environments
+      when: (not service) and (not group_environment) or group_environment in item.environments
       become: true
       become_user: "{{ common_web_user }}"
 
@@ -159,7 +159,7 @@
         {% if item.get('unusable_password') %}--unusable-password{% endif %}
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: "{{ django_users }}"
-      when: not item.get('unusable_password')
+      when: (not service) and (not item.get('unusable_password'))
       register: manage_users_result
       failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors | bool)
       retries: 3
@@ -180,7 +180,7 @@
         {% if item.get('unusable_password') %}--unusable-password{% endif %}
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: "{{ django_users }}"
-      when: item.get('unusable_password')
+      when: (not service) and item.get('unusable_password')
       register: manage_users_result
       failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors | bool)
       retries: 3


### PR DESCRIPTION
### Description

Tasks that create django users for IDAs would run when creating django users for `edx-platform`. In their `manage.py` command they would omit `lms` or `cms` (because they are targeting IDAs), and that would cause the tasks to fail, because when running `manage.py` commands in `edx-platform`, passing `lms` or `cms` is mandatory.

Since these tasks should only run when targeting IDAs, added a predicate, that checks that `service` variable is not an empty string. That way these tasks will only be executed when the playbook is used to create a django user for an IDA.

### Links

[BB-6458](https://tasks.opencraft.com/browse/BB-6458)
