### PR TITLE
[BACKPORT][BB-6428] fix: Adding a missing space to the single-beat binary call in beat_sc…

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/beat_scheduler.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/beat_scheduler.sh.j2
@@ -14,7 +14,7 @@ if command -v ec2metadata >/dev/null 2>&1; then
   export NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="$HOSTNAME-$INSTANCEID"
 fi
 {% else %}
-{% set executable = edxapp_venv_bin + '/single-beat' + edxapp_venv_bin + '/celery' %}
+{% set executable = edxapp_venv_bin + '/single-beat ' + edxapp_venv_bin + '/celery' %}
 {% endif %}
 
 # We exec so that celery is the child of supervisor and can be managed properly


### PR DESCRIPTION
# Description

Backports the fix for Celerybeat. It's identical to https://github.com/open-craft/configuration/commit/1aca66d6eec899d3883a73681f099fc937395084, so no testing is needed.