### PR TITLE
[SE-5456] cherry-pick confiruation/pull/6483

### DIFF
--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -119,7 +119,6 @@
     - role: demo
       when: DEMO_ROLE_ENABLED
     - oauth_client_setup
-    - oraclejdk
     - role: elasticsearch
       when: EDXAPP_ENABLE_ELASTIC_SEARCH
     - forum

--- a/playbooks/roles/elasticsearch/meta/main.yml
+++ b/playbooks/roles/elasticsearch/meta/main.yml
@@ -1,4 +1,3 @@
 ---
 dependencies:
   - common
-  - oraclejdk

--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -5,7 +5,6 @@
 # Dependencies:
 #
 #   * common
-#   * oraclejdk
 #
 # Example play:
 #
@@ -25,11 +24,10 @@
 # -  hosts: tag_role_elasticsearch:&tag_environment_stage
 #    roles:
 #    - common
-#    - oraclejdk
 #    - elasticsearch
 #
 
-- name: Install Elasticsearch repo key 
+- name: Install Elasticsearch repo key
   apt_key:
     url: "{{ elasticsearch_apt_key_url }}"
     state: present
@@ -48,9 +46,9 @@
 - name: install elasticsearch
   apt:
     pkg: "{{ elasticsearch_package_name }}={{ ELASTICSEARCH_VERSION }}"
-    state: present 
+    state: present
     install_recommends: yes
-    force: yes 
+    force: yes
     update_cache: yes
   tags:
     - install
@@ -78,7 +76,7 @@
 
 - name: update elasticsearch defaults
   template:
-    src: etc/default/elasticsearch.j2 
+    src: etc/default/elasticsearch.j2
     dest: /etc/default/elasticsearch
   tags:
     - install
@@ -86,7 +84,7 @@
 
 - name: drop the elasticsearch config
   template:
-    src: edx/etc/elasticsearch/elasticsearch.yml.j2 
+    src: edx/etc/elasticsearch/elasticsearch.yml.j2
     dest: "{{ elasticsearch_cfg_dir }}/elasticsearch.yml"
     mode: 0644
   tags:
@@ -122,18 +120,18 @@
     - install:configuration
 
 - name: Ensure elasticsearch is enabled and started
-  service: 
+  service:
     name: elasticsearch
-    state: started 
+    state: started
     enabled: yes
   tags:
     - manage
     - manage:start
 
 - name: Restart elastic when there has been an upgrade
-  service: 
-    name: elasticsearch 
-    state: restarted 
+  service:
+    name: elasticsearch
+    state: restarted
     enabled: yes
   when: elasticsearch_reinstall.changed
   tags:


### PR DESCRIPTION
[FAL-2000] Remove jdk role from openedx-native playbook and elasticsearch role dependencies (#6483)

* remove depedency to oraclejdk in elasticsearch role
* remove jdk from opencraft_native

**Testing**

1. Verify [the test appserver](https://stage.manage.opencraft.com/instance/9620/edx-appserver/3779/) provisioned successfully.
2. Verify that forum search (which is backed by ES) works.