### PR TITLE
fix: enable Celery workers in supervisor for edx_django_service role [BB-7002]

### DIFF
--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -347,6 +347,17 @@
     - install
     - install:configuration
 
+- name: enable celery worker supervisor script
+  when: edx_django_service_enable_celery_workers
+  file:
+    src: "{{ supervisor_available_dir }}/{{ edx_django_service_workers_supervisor_conf }}"
+    dest: "{{ supervisor_cfg_dir }}/{{ edx_django_service_workers_supervisor_conf }}"
+    state: link
+    force: yes
+  tags:
+    - install
+    - install:configuration
+
 - name: update supervisor configuration
   command: "{{ supervisor_ctl }} -c {{ supervisor_cfg }} update"
   when: not disable_edx_services


### PR DESCRIPTION
Previously, these configurations were added only to the `supervisor_available_dir`. No step would enable these configurations, though.

This can be verified by deploying the `enterprise_catalog` playbook.


This backports https://github.com/openedx/configuration/pull/6884 to Nutmeg.